### PR TITLE
Enable SDDM auto-login for user "desktop"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -169,8 +169,8 @@
             # };
             # services.xserver.enable = true;
             services.displayManager.sddm.enable = true;
-            # services.displayManager.autoLogin.enable = true;
-            # services.displayManager.autoLogin.user = "desktop";
+            services.displayManager.autoLogin.enable = true;
+            services.displayManager.autoLogin.user = "desktop";
             services.displayManager.sddm.wayland.enable = true;
             services.desktopManager.plasma6.enable = true;
             services.displayManager.defaultSession = "hyprland";


### PR DESCRIPTION
- Uncommented the `autoLogin` settings in `flake.nix`.
- Configured SDDM to automatically log in the user "desktop".
- Useful for streamlined startup in a graphical session.