### PR TITLE
Switch to English locale

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -102,18 +102,18 @@
   # Set your time zone.
   time.timeZone = "Europe/Paris";
 
-  # Set default locale and additional locale settings for internationalization.
-  i18n.defaultLocale = "fr_FR.UTF-8";
+  # Set default locale to English while keeping the keyboard layout in French.
+  i18n.defaultLocale = "en_US.UTF-8";
   i18n.extraLocaleSettings = {
-    LC_ADDRESS       = "fr_FR.UTF-8";
-    LC_IDENTIFICATION = "fr_FR.UTF-8";
-    LC_MEASUREMENT   = "fr_FR.UTF-8";
-    LC_MONETARY      = "fr_FR.UTF-8";
-    LC_NAME          = "fr_FR.UTF-8";
-    LC_NUMERIC       = "fr_FR.UTF-8";
-    LC_PAPER         = "fr_FR.UTF-8";
-    LC_TELEPHONE     = "fr_FR.UTF-8";
-    LC_TIME          = "fr_FR.UTF-8";
+    LC_ADDRESS       = "en_US.UTF-8";
+    LC_IDENTIFICATION = "en_US.UTF-8";
+    LC_MEASUREMENT   = "en_US.UTF-8";
+    LC_MONETARY      = "en_US.UTF-8";
+    LC_NAME          = "en_US.UTF-8";
+    LC_NUMERIC       = "en_US.UTF-8";
+    LC_PAPER         = "en_US.UTF-8";
+    LC_TELEPHONE     = "en_US.UTF-8";
+    LC_TIME          = "en_US.UTF-8";
   };
 
   ##############################

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -21,8 +21,8 @@ This file is the heart of the system configuration. Key areas include:
 3. **Boot Settings** – systemd-boot with EFI support, kernel modules (e.g., `v4l2loopback`), and plymouth splash.
 4. **Security** – enabling policykit and realtime kit.
 5. **Networking** – hostname, firewall defaults, wireless support, and NetworkManager.
-6. **Locale & Time** – timezone `Europe/Paris` with French locales.
-7. **Console and X11** – sets French keyboard layout and console fonts.
+6. **Locale & Time** – timezone `Europe/Paris` with English locales.
+7. **Console and X11** – keeps the French keyboard layout while the system language is English.
 8. **Fonts** – installs a selection of fonts including JetBrains Mono and Noto packages.
 9. **Users** – defines `laptop`, `desktop`, and `sinusbot` users with group memberships.
 10. **Nix Settings** – allows unfree packages, sets flake registry, and configures nix path.


### PR DESCRIPTION
## Summary
- set default locale to English while keeping the keyboard in French
- update docs to mention English locale

## Testing
- `nix flake check --print-build-logs` *(fails: `nix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5bfb605c833198b92f3ede01d571