### PR TITLE
docs: add Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # NixOS Configuration
 
 This repository contains the NixOS configuration for both a desktop and a laptop setup. For a full description of the available modules and options see [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
+
+## Getting Started
+
+1. Clone the repository:
+   ```sh
+   git clone https://github.com/<your-username>/nixos-config.git
+   cd nixos-config
+   ```
+
+2. Apply the configuration for a host:
+   ```sh
+   sudo nixos-rebuild switch --flake .#desktop
+   ```
+   Use `.#laptop` in place of `.#desktop` to build the laptop configuration.
+
+Home-manager modules for each user are included automatically via the flake.
+


### PR DESCRIPTION
## Summary
- document how to clone and apply the configuration
- clarify that home-manager modules come via the flake

## Testing
- `nix flake check` *(fails: `nix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ca09c5980833196d3205451be93c5