### PR TITLE
Enable autologin for laptop

### DIFF
--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -20,4 +20,13 @@
 
   home-manager.users.laptop = import ../../home-laptop.nix;
   nix.settings.trusted-users = [ "laptop" ];
+
+  services.displayManager = {
+    sddm.enable = true;
+    autoLogin.enable = true;
+    autoLogin.user = "laptop";
+    sddm.wayland.enable = true;
+  };
+  services.desktopManager.plasma6.enable = true;
+  services.displayManager.defaultSession = "hyprland";
 }


### PR DESCRIPTION
## Summary
- enable SDDM with autologin for laptop configuration

## Testing
- `nix flake check` *(fails: `nix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca633882883319b943bb00038cfdb