### PR TITLE
Desktop hyprpanel longlaunchfix

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -32,10 +32,6 @@
   hardware.logitech.wireless.enable = true;
   hardware.logitech.wireless.enableGraphical = true;
 
-  # Enable Bluetooth and its graphical manager.
-  hardware.bluetooth.enable = false;
-  hardware.bluetooth.powerOnBoot = false;
-  services.blueman.enable = false;
 
   hardware.nvidia-container-toolkit.enable = true;
   ##############################

--- a/configuration.nix
+++ b/configuration.nix
@@ -33,9 +33,9 @@
   hardware.logitech.wireless.enableGraphical = true;
 
   # Enable Bluetooth and its graphical manager.
-  hardware.bluetooth.enable = true;
-  hardware.bluetooth.powerOnBoot = true;
-  services.blueman.enable = true;
+  hardware.bluetooth.enable = false;
+  hardware.bluetooth.powerOnBoot = false;
+  services.blueman.enable = false;
 
   hardware.nvidia-container-toolkit.enable = true;
   ##############################

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -17,7 +17,7 @@ Each configuration pulls in common modules like `configuration.nix`, GPU configu
 This file is the heart of the system configuration. Key areas include:
 
 1. **Imports** – brings in other modules such as custom packages from `packages.nix`.
-2. **Hardware & Virtualization** – enables virtualbox, libvirtd, Logitech device support, Bluetooth, and more. ZRAM swap is also activated.
+2. **Hardware & Virtualization** – enables virtualbox, libvirtd, Logitech device support, and other hardware options. ZRAM swap is also activated. Bluetooth is enabled only for the laptop host.
 3. **Boot Settings** – systemd-boot with EFI support, kernel modules (e.g., `v4l2loopback`), and plymouth splash.
 4. **Security** – enabling policykit and realtime kit.
 5. **Networking** – hostname, firewall defaults, wireless support, and NetworkManager.
@@ -91,7 +91,7 @@ machine‑specific options. Below is a summary of the two provided hosts:
 - **laptop**
   - Imports `hardware-configuration-laptop.nix` with both AMD and NVIDIA GPU
     modules.
-  - Enables Bluetooth (with the Blueman applet) and provides a 16 GiB swap
+  - Enables Bluetooth (with the Blueman applet) so the service starts automatically, and provides a 16 GiB swap
     file at `/var/lib/swapfile`.
   - Allows a small set of firewall ports: 80, 91, 443, 444, 8501 and 9100.
 

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -12,6 +12,7 @@
   };
 
   hardware.bluetooth.enable = true;
+  hardware.bluetooth.powerOnBoot = true;
   services.blueman.enable = true;
   swapDevices = [{
     device = "/var/lib/swapfile";


### PR DESCRIPTION
Enable Bluetooth only on laptop host to fix long start up of hyprpanel