### PR TITLE
Update configuration docs for Hyprpanel and Hyprsunset

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,7 +28,7 @@ This file is the heart of the system configuration. Key areas include:
 10. **Nix Settings** – allows unfree packages, sets flake registry, and configures nix path.
 11. **Environment** – sets global environment variables and enables Zsh.
 12. **Services** – enables Flatpak, Udisks2, Emacs daemon, and XDG portals.
-13. **Programs** – Hyprland, KDE Connect, Gamemode, Yazi file manager with custom keymap, CoreCtrl for hardware control, and more.
+13. **Programs** – Hyprland, KDE Connect, Gamemode, Yazi file manager with custom keymap, CoreCtrl for hardware control, and more. Hyprland also launches Hyprpanel (themes in `hyprpanel_themes/`) and the `hyprsunset.sh` script.
 14. **Audio** – uses Pipewire with PulseAudio disabled.
 15. **Stylix** – manages desktop theming and fonts.
 16. **System Maintenance** – placeholder for garbage collection settings.
@@ -100,7 +100,9 @@ machine‑specific options. Below is a summary of the two provided hosts:
 - `droidcam.nix` and `v4l2loopback-dc.nix` – provide DroidCam and its kernel module.
 - `python.nix` – defines a set of Python packages using `pkgs.python3.withPackages`.
 - `ollama.nix` – builds the Ollama AI application with optional ROCm or CUDA support.
-
+- Hyprpanel is provided as an overlay through `common-modules.nix`. Themes live in `hyprpanel_themes/`.
+- `hyprsunset.sh` – a script launched by Hyprland to adjust screen color at sunset.
+- System programs like **Yazi** and **CoreCtrl** are enabled in `configuration.nix` (see Core System Configuration, item 13).
 
 ---
 


### PR DESCRIPTION
## Summary
- document Hyprpanel overlay and theme location
- describe Hyprsunset script launched by Hyprland
- mention programs like Yazi and CoreCtrl in the docs

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684e063a60b08331b3325d8f85875f34