### PR TITLE
Improve hyprsunset automation

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -275,9 +275,11 @@
 
   # Start the hyprsunset daemon as a user service
   systemd.user.services.hyprsunset = {
-    Unit = { Description = "Hyprsunset color temperature control"; };
-    Service = { ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset"; };
-    Install = { WantedBy = [ "graphical-session.target" ]; };
+    description = "Hyprsunset color temperature control";
+    serviceConfig = {
+      ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset";
+    };
+    wantedBy = [ "graphical-session.target" ];
   };
 
   # Enable KDE Connect for device integration.

--- a/configuration.nix
+++ b/configuration.nix
@@ -273,6 +273,13 @@
   programs.hyprland.enable = true;
   programs.hyprlock.enable = true;
 
+  # Start the hyprsunset daemon as a user service
+  systemd.user.services.hyprsunset = {
+    Unit = { Description = "Hyprsunset color temperature control"; };
+    Service = { ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset"; };
+    Install = { WantedBy = [ "graphical-session.target" ]; };
+  };
+
   # Enable KDE Connect for device integration.
   programs.kdeconnect.enable = true;
 

--- a/configuration.nix
+++ b/configuration.nix
@@ -277,7 +277,9 @@
   systemd.user.services.hyprsunset = {
     description = "Hyprsunset color temperature control";
     serviceConfig = {
-      ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset";
+      # Start hyprsunset with --identity so the display
+      # color is initially unmodified until adjusted by hyprsunset.sh
+      ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset --identity";
     };
     wantedBy = [ "graphical-session.target" ];
   };

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -35,7 +35,7 @@ This file is the heart of the system configuration. Key areas include:
 10. **Nix Settings** – allows unfree packages, sets flake registry, and configures nix path.
 11. **Environment** – sets global environment variables and enables Zsh.
 12. **Services** – enables Flatpak, Udisks2, Emacs daemon, and XDG portals.
-13. **Programs** – Hyprland, KDE Connect, Gamemode, Yazi file manager with custom keymap, CoreCtrl for hardware control, and more. Hyprland also launches Hyprpanel (themes in `hyprpanel_themes/`) and the `hyprsunset.sh` script which adjusts the screen temperature based on sunrise and sunset times.
+13. **Programs** – Hyprland, KDE Connect, Gamemode, Yazi file manager with custom keymap, CoreCtrl for hardware control, and more. Hyprland also launches Hyprpanel (themes in `hyprpanel_themes/`) and the `hyprsunset.sh` script. The hyprsunset daemon itself runs as a systemd user service to adjust the screen temperature based on sunrise and sunset times.
 14. **Audio** – uses Pipewire with PulseAudio disabled.
 15. **Stylix** – manages desktop theming and fonts.
 16. **System Maintenance** – placeholder for garbage collection settings.
@@ -225,17 +225,17 @@ time falls between sunset and sunrise. If so, it lowers the screen temperature
 to 4000 K; otherwise it restores the `identity` temperature. Manual
 temperature changes are respected: if the user sets the temperature to
 `identity` while the sun is down, the script pauses until the temperature
-drops again. Failed API lookups are ignored until the next interval. To automatically
-enable it in
-Hyprland add
-the following line to your configuration:
+drops again. Failed API lookups are ignored until the next interval.
+Hyprsunset itself runs as a systemd user service. To launch the helper script in
+Hyprland add the following line to your configuration:
 
 ```ini
 exec-once = ~/Documents/nix-configuration/hyprsunset.sh
 ```
 
 The script logs its actions to `~/hyprsunset.log` so you can troubleshoot any
-issues that arise.
+issues that arise. The current temperature is determined by reading the latest
+"Received a request" entry from the hyprsunset systemd journal.
 
 Dependencies: `curl` and `jq` need to be available.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -35,7 +35,7 @@ This file is the heart of the system configuration. Key areas include:
 10. **Nix Settings** – allows unfree packages, sets flake registry, and configures nix path.
 11. **Environment** – sets global environment variables and enables Zsh.
 12. **Services** – enables Flatpak, Udisks2, Emacs daemon, and XDG portals.
-13. **Programs** – Hyprland, KDE Connect, Gamemode, Yazi file manager with custom keymap, CoreCtrl for hardware control, and more. Hyprland also launches Hyprpanel (themes in `hyprpanel_themes/`) and the `hyprsunset.sh` script.
+13. **Programs** – Hyprland, KDE Connect, Gamemode, Yazi file manager with custom keymap, CoreCtrl for hardware control, and more. Hyprland also launches Hyprpanel (themes in `hyprpanel_themes/`) and the `hyprsunset.sh` script which adjusts the screen temperature based on sunrise and sunset times.
 14. **Audio** – uses Pipewire with PulseAudio disabled.
 15. **Stylix** – manages desktop theming and fonts.
 16. **System Maintenance** – placeholder for garbage collection settings.
@@ -108,7 +108,7 @@ machine‑specific options. Below is a summary of the two provided hosts:
 - `python.nix` – defines a set of Python packages using `pkgs.python3.withPackages`.
 - `ollama.nix` – builds the Ollama AI application with optional ROCm or CUDA support.
 -  Hyprpanel is provided as an overlay through `common-modules.nix`. Themes live in `hyprpanel_themes/`.
-- `hyprsunset.sh` – a script launched by Hyprland to adjust screen color at sunset.
+- `hyprsunset.sh` – a script launched by Hyprland to adjust screen color automatically: 4000 K at night and `identity` during the day.
 - System programs like **Yazi** and **CoreCtrl** are enabled in `configuration.nix` (see Core System Configuration, item 13).
 
 ## Adding a new host
@@ -220,13 +220,22 @@ documented in that file.
 
 The repository includes a small helper script `hyprsunset.sh`. It queries the
 [sunrisesunset.io](https://sunrisesunset.io/) API with `curl` and `jq` to obtain
-today's sunset time, sleeps until that moment and then applies a warm colour
-temperature via `hyprctl hyprsunset`. To automatically enable it in Hyprland add
+both sunrise and sunset times. Every few minutes it checks whether the current
+time falls between sunset and sunrise. If so, it lowers the screen temperature
+to 4000 K; otherwise it restores the `identity` temperature. Manual
+temperature changes are respected: if the user sets the temperature to
+`identity` while the sun is down, the script pauses until the temperature
+drops again. Failed API lookups are ignored until the next interval. To automatically
+enable it in
+Hyprland add
 the following line to your configuration:
 
 ```ini
 exec-once = ~/Documents/nix-configuration/hyprsunset.sh
 ```
+
+The script logs its actions to `~/hyprsunset.log` so you can troubleshoot any
+issues that arise.
 
 Dependencies: `curl` and `jq` need to be available.
 

--- a/hyprland.base.conf
+++ b/hyprland.base.conf
@@ -7,7 +7,6 @@
 # For a full list, see the wiki
 #
 
-exec-once = hyprsunset
 exec-once = ~/Documents/nix-configuration/hyprsunset.sh
 exec-once = hyprpanel
 exec-once = emacs --daemon

--- a/hyprsunset.sh
+++ b/hyprsunset.sh
@@ -31,7 +31,8 @@ fetch_times() {
 }
 
 get_temp() {
-  hyprctl -j hyprsunset 2>/dev/null | jq -r '.temperature // empty'
+  journalctl --user -u hyprsunset.service -n 20 --no-pager |
+    awk '/Received a request:/ { t=$NF } END { if (t) print t }'
 }
 
 set_temp() {

--- a/hyprsunset.sh
+++ b/hyprsunset.sh
@@ -1,24 +1,93 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
-# Coordonnées de Bouc-Bel-Air
+LOG_FILE="$HOME/hyprsunset.log"
+
+log() {
+  printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >> "$LOG_FILE"
+}
+
+log "Starting hyprsunset"
+
+# Coordinates for Bouc-Bel-Air
 LAT=43.452
 LON=5.413
 TIMEZONE="Europe/Paris"
 
-# Obtenir l'heure du coucher du soleil en UTC
-sunset_utc=$(curl -s "https://api.sunrisesunset.io/json?lat=$LAT&lng=$LON&date=today&timezone=$TIMEZONE" | jq -r '.results.sunset')
+INTERVAL=300  # check every 5 minutes
+API="https://api.sunrisesunset.io/json?lat=$LAT&lng=$LON&date=today&timezone=$TIMEZONE"
 
-# Convertir l'heure du coucher du soleil en format UNIX
-sunset_unix=$(date -d "$sunset_utc" +%s)
+fetch_times() {
+  local data
+  if ! data=$(curl -sf "$API"); then
+    log "Failed to query sunrise/sunset"
+    return 1
+  fi
+  sunrise=$(echo "$data" | jq -r '.results.sunrise')
+  sunset=$(echo "$data" | jq -r '.results.sunset')
+  sunrise_unix=$(TZ="$TIMEZONE" date -d "$sunrise" +%s)
+  sunset_unix=$(TZ="$TIMEZONE" date -d "$sunset" +%s)
+  log "Sunrise: $sunrise ($sunrise_unix), Sunset: $sunset ($sunset_unix)"
+}
 
-# Heure actuelle en format UNIX
-current_time=$(date +%s)
+get_temp() {
+  hyprctl -j hyprsunset 2>/dev/null | jq -r '.temperature // empty'
+}
 
-# Calculer le délai jusqu'au coucher du soleil
-delay=$((sunset_unix - current_time))
+set_temp() {
+  log "Setting temperature to $1"
+  if [[ "$1" == "identity" ]]; then
+    hyprctl hyprsunset identity
+  else
+    hyprctl hyprsunset temperature "$1"
+  fi
+}
 
-# Attendre jusqu'au coucher du soleil
-sleep $delay
+manual_override=false
 
-# Appliquer le filtre Hyprsunset
-hyprctl hyprsunset temperature 4000
+while true; do
+  if ! fetch_times; then
+    echo "Failed to query sunrise/sunset" >&2
+    sleep "$INTERVAL"
+    continue
+  fi
+
+  now=$(date +%s)
+  current_temp=$(get_temp)
+
+  if (( now >= sunset_unix || now < sunrise_unix )); then
+    log "Nighttime - current temp: ${current_temp:-none}"
+
+    # Detect a manual override whenever the user selects the identity
+    # temperature at night. The script waits until it is changed again
+    # before resuming automatic control.
+    if [[ "$current_temp" == "identity" ]]; then
+      if ! $manual_override; then
+        log "Manual temperature override detected"
+      fi
+      manual_override=true
+    fi
+
+    if $manual_override; then
+      if [[ "$current_temp" != "identity" ]]; then
+        log "Manual override ended"
+        manual_override=false
+      else
+        sleep "$INTERVAL"
+        continue
+      fi
+    fi
+
+    if [[ -z "$current_temp" || "$current_temp" != "4000" ]]; then
+      set_temp 4000
+    fi
+  else
+    log "Daytime - current temp: ${current_temp:-none}"
+    manual_override=false
+    if [[ -z "$current_temp" || "$current_temp" != "identity" ]]; then
+      set_temp identity
+    fi
+  fi
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
## Summary
- document new hyprsunset behaviour with identity temperature
- during daytime set hyprsunset to identity instead of 6000K
- treat identity at night as a manual override

## Testing
- `bash -n hyprsunset.sh`


------
https://chatgpt.com/codex/tasks/task_e_6851227d47f08331967917e66f118cdf