### PR TITLE
Fix hyprsunset user service syntax

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -275,9 +275,11 @@
 
   # Start the hyprsunset daemon as a user service
   systemd.user.services.hyprsunset = {
-    Unit = { Description = "Hyprsunset color temperature control"; };
-    Service = { ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset"; };
-    Install = { WantedBy = [ "graphical-session.target" ]; };
+    description = "Hyprsunset color temperature control";
+    serviceConfig = {
+      ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset";
+    };
+    wantedBy = [ "graphical-session.target" ];
   };
 
   # Enable KDE Connect for device integration.

--- a/configuration.nix
+++ b/configuration.nix
@@ -277,7 +277,9 @@
   systemd.user.services.hyprsunset = {
     description = "Hyprsunset color temperature control";
     serviceConfig = {
-      ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset";
+      # Start hyprsunset with --identity so the display
+      # color is initially unmodified until adjusted by hyprsunset.sh
+      ExecStart = "${pkgs.hyprsunset}/bin/hyprsunset --identity";
     };
     wantedBy = [ "graphical-session.target" ];
   };


### PR DESCRIPTION
## Summary
- update hyprsunset systemd user service syntax so it builds

## Testing
- `nix flake check --show-trace` *(fails: `nix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528393d4f883318c9f7b676b2fedb2