### PR TITLE
Optimize network startup

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -90,6 +90,17 @@
   # Enable NetworkManager for easier network management.
   networking.networkmanager.enable = true;
 
+  # Optimize DHCP client startup and avoid waiting for the network
+  networking.dhcpcd.wait = "background";
+  networking.dhcpcd.extraConfig = ''
+    timeout 1
+    noarp
+    nodelay
+  '';
+
+  # Skip waiting for full network connectivity during boot
+  systemd.services."NetworkManager-wait-online".enable = false;
+
 
   networking.enableIPv6  = false;
   ##############################


### PR DESCRIPTION
## Summary
- run DHCP in background with minimal timeout
- skip the NetworkManager-wait-online unit

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check --no-build --print-build-logs` *(fails: path '/nix/store/b9vhih6z1rs42k1hwl3g5awd96dv4g4r-base16-schemes-0-unstable-2025-06-04.drv' is not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68529d7a3c50833184d6e3ee1bd128da