### PR TITLE
Enable hypridle with 5/6 minute timeout

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -274,9 +274,10 @@
   ##############################
   # 14. Application & Program Settings
   ##############################
-  # Enable Hyprland (a Wayland compositor) & Hyprlock.
+  # Enable Hyprland (a Wayland compositor) & Hyprlock/Hypridle.
   programs.hyprland.enable = true;
   programs.hyprlock.enable = true;
+  services.hypridle.enable = true;
 
   # Start the hyprsunset daemon as a user service
   systemd.user.services.hyprsunset = {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -238,6 +238,14 @@ issues that arise. The current temperature is determined by reading the latest
 
 Dependencies: `curl` and `jq` need to be available.
 
+## Hypridle
+
+Hypridle runs as a user service and monitors inactivity. The bundled
+`hypridle.conf` locks the session after 5 minutes and powers off the display
+after 6 minutes. The configuration is installed to
+`~/.config/hypr/hypridle.conf` for each user and the service itself is enabled
+in `configuration.nix`.
+
 ## Adding a new host
 
 Follow these steps to create another machine configuration:

--- a/home-desktop.nix
+++ b/home-desktop.nix
@@ -34,6 +34,7 @@
   home.file.".config/hyprpanel/config.json".source = ./hm/hyprpanel/config.json;
   home.file.".config/hyprpanel/modules.json".source = ./hm/hyprpanel/modules.json;
   home.file.".config/hyprpanel/modules.scss".source = ./hm/hyprpanel/modules.scss;
+  home.file.".config/hypr/hypridle.conf".source = ./hypridle.conf;
   programs.git = {
     enable = true;
     userName = "Alto";

--- a/home-laptop.nix
+++ b/home-laptop.nix
@@ -36,6 +36,7 @@
   home.file.".config/hyprpanel/config.json".source = ./hm/hyprpanel/config-laptop.json;
   home.file.".config/hyprpanel/modules.json".source = ./hm/hyprpanel/modules.json;
   home.file.".config/hyprpanel/modules.scss".source = ./hm/hyprpanel/modules.scss;
+  home.file.".config/hypr/hypridle.conf".source = ./hypridle.conf;
   programs.git = {
     enable = true;
     userName = "Alto";

--- a/hypridle.conf
+++ b/hypridle.conf
@@ -1,0 +1,23 @@
+# Hypridle configuration
+
+# General settings - automatically lock using hyprlock and handle DPMS
+# when the system goes to sleep or wakes up
+
+general {
+    lock_cmd = pidof hyprlock || hyprlock
+    before_sleep_cmd = loginctl lock-session
+    after_sleep_cmd = hyprctl dispatch dpms on
+}
+
+# Lock the session after 5 minutes of inactivity
+listener {
+    timeout = 300
+    on-timeout = loginctl lock-session
+}
+
+# Turn off the screen one minute later
+listener {
+    timeout = 360
+    on-timeout = hyprctl dispatch dpms off
+    on-resume = hyprctl dispatch dpms on
+}


### PR DESCRIPTION
## Summary
- add hypridle service and config file
- install config for desktop and laptop users
- document hypridle in CONFIGURATION.md

## Testing
- `nix flake check` *(fails: requires accept-flake-config)*

------
https://chatgpt.com/codex/tasks/task_e_6853e25d33e08331a0843b7ed295b77d