### PR TITLE
Add hyprlock config to home-manager

### DIFF
--- a/home-desktop.nix
+++ b/home-desktop.nix
@@ -35,6 +35,8 @@
   home.file.".config/hyprpanel/modules.json".source = ./hm/hyprpanel/modules.json;
   home.file.".config/hyprpanel/modules.scss".source = ./hm/hyprpanel/modules.scss;
   home.file.".config/hypr/hypridle.conf".source = ./hypridle.conf;
+  home.file.".config/hypr/hyprlock.conf".source = ./hm/hyprlock/hyprlock.conf;
+  home.file.".config/hypr/catppuccin_hyprlock_background_sapphire.jpg".source = ./hm/hyprlock/catppuccin_hyprlock_background_sapphire.jpg;
   programs.git = {
     enable = true;
     userName = "Alto";

--- a/home-laptop.nix
+++ b/home-laptop.nix
@@ -37,6 +37,8 @@
   home.file.".config/hyprpanel/modules.json".source = ./hm/hyprpanel/modules.json;
   home.file.".config/hyprpanel/modules.scss".source = ./hm/hyprpanel/modules.scss;
   home.file.".config/hypr/hypridle.conf".source = ./hypridle.conf;
+  home.file.".config/hypr/hyprlock.conf".source = ./hm/hyprlock/hyprlock.conf;
+  home.file.".config/hypr/catppuccin_hyprlock_background_sapphire.jpg".source = ./hm/hyprlock/catppuccin_hyprlock_background_sapphire.jpg;
   programs.git = {
     enable = true;
     userName = "Alto";


### PR DESCRIPTION
## Summary
- link hyprlock configuration and background through home-manager for laptop and desktop setups

## Testing
- `nix --extra-experimental-features 'nix-command flakes' eval .#nixosConfigurations.laptop.config.networking.hostName --impure`
- `nix --extra-experimental-features 'nix-command flakes' eval .#nixosConfigurations.desktop.config.networking.hostName --impure`


------
https://chatgpt.com/codex/tasks/task_e_6855234081888331ad0f3c86c8f24017