### PR TITLE
Restrict NVIDIA configuration to desktop only

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -33,7 +33,6 @@
   hardware.logitech.wireless.enableGraphical = true;
 
 
-  hardware.nvidia-container-toolkit.enable = true;
   ##############################
   # 3. Boot & Kernel Settings
   ##############################

--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -24,4 +24,6 @@
   };
   services.desktopManager.plasma6.enable = true;
   services.displayManager.defaultSession = "hyprland";
+
+  hardware.nvidia-container-toolkit.enable = true;
 }

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -3,7 +3,6 @@
   imports = [
     ../../hardware-configuration-laptop.nix
     ../../amdgpu.nix
-    ../../nvidiagpu.nix
     ../../packages/laptop.nix
     ../../tlp.nix
   ];


### PR DESCRIPTION
- Removed global `hardware.nvidia-container-toolkit.enable` setting from `configuration.nix`.
- Moved NVIDIA toolkit enablement into `hosts/desktop/default.nix` to apply only on the desktop host.
- Removed `nvidiagpu.nix` import from the laptop configuration to prevent unnecessary configuration.