### PR TITLE
Add Tailscale VPN service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ This repository contains the NixOS configuration for both a desktop and a laptop
 
 Home-manager modules for each user are included automatically via the flake.
 
+### Tailscale VPN
+
+After switching to the configuration, run the following command on each machine
+to join your Tailnet:
+
+```sh
+sudo tailscale up --auth-key=<YOUR_KEY>
+```
+
+Replace `<YOUR_KEY>` with an auth key created at
+<https://login.tailscale.com/admin/machines/new-linux>.
+

--- a/configuration.nix
+++ b/configuration.nix
@@ -89,6 +89,9 @@
   # Enable NetworkManager for easier network management.
   networking.networkmanager.enable = true;
 
+  # Enable Tailscale VPN service
+  services.tailscale.enable = true;
+
   # Optimize DHCP client startup and avoid waiting for the network
   networking.dhcpcd.wait = "background";
   networking.dhcpcd.extraConfig = ''

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -34,7 +34,8 @@ This file is the heart of the system configuration. Key areas include:
 9. **Users** – defines `laptop` and `desktop` users with group memberships.
 10. **Nix Settings** – allows unfree packages, sets flake registry, and configures nix path.
 11. **Environment** – sets global environment variables and enables Zsh.
-12. **Services** – enables Flatpak, Udisks2, Emacs daemon, and XDG portals.
+12. **Services** – enables Flatpak, Udisks2, Emacs daemon, XDG portals, and the
+    Tailscale VPN service.
 13. **Programs** – Hyprland, KDE Connect, Gamemode, Yazi file manager with custom keymap, CoreCtrl for hardware control, and more. Hyprland also launches Hyprpanel (themes in `hyprpanel_themes/`) and the `hyprsunset.sh` script. The hyprsunset daemon itself runs as a systemd user service to adjust the screen temperature based on sunrise and sunset times.
 14. **Audio** – uses Pipewire with PulseAudio disabled.
 15. **Stylix** – manages desktop theming and fonts.
@@ -245,6 +246,13 @@ Hypridle runs as a user service and monitors inactivity. The bundled
 after 6 minutes. The configuration is installed to
 `~/.config/hypr/hypridle.conf` for each user and the service itself is enabled
 in `configuration.nix`.
+
+## Tailscale VPN
+
+Both hosts have `services.tailscale.enable = true` in the system
+configuration. After rebuilding, use `sudo tailscale up --auth-key=<KEY>`
+to authenticate the machine and join your Tailnet. Generate a key from the
+Tailscale admin console.
 
 ## Adding a new host
 


### PR DESCRIPTION
## Summary
- enable Tailscale in the base system config
- document Tailscale usage in README and docs

## Testing
- `nix flake check --no-build --show-trace` *(fails: path '/nix/store/75r552b14k756fncm7bf1nzyx6gx004k-base16-schemes-0-unstable-2025-06-04.drv' is not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68628cfc51208331842efd3bc6e03b60