### PR TITLE
Configure laptop hyprland for external HDMI monitor

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -247,6 +247,13 @@ after 6 minutes. The configuration is installed to
 `~/.config/hypr/hypridle.conf` for each user and the service itself is enabled
 in `configuration.nix`.
 
+## Laptop HDMI monitor configuration
+
+When a second monitor is attached to the laptop via HDMI, Hyprland automatically
+places it on the right side of the built-in display. Workspaces 6–10 are mapped
+to this output so that they appear on the external screen whenever it is
+present. The full configuration is available in `wm-laptop/hyprland.conf`.
+
 ## Tailscale VPN
 
 Both hosts have `services.tailscale.enable = true` in the system

--- a/wm-laptop/hyprland.conf
+++ b/wm-laptop/hyprland.conf
@@ -1,7 +1,10 @@
 # Laptop-specific Hyprland settings
 
 # Monitor configuration
-monitor=eDP-1,1920x1080@60,auto,auto
+# Internal laptop display
+monitor=eDP-1,1920x1080@60,0x0,1.5
+# Optional HDMI monitor positioned to the right
+monitor=HDMI-A-1,1920x1080@60,1280x0,1
 
 # Workspaces mapped to monitor
 workspace=1,monitor:eDP-1,default:true
@@ -9,8 +12,9 @@ workspace=2,monitor:eDP-1
 workspace=3,monitor:eDP-1
 workspace=4,monitor:eDP-1
 workspace=5,monitor:eDP-1
-workspace=6,monitor:eDP-1
-workspace=7,monitor:eDP-1
-workspace=8,monitor:eDP-1
-workspace=9,monitor:eDP-1
-workspace=10,monitor:eDP-1
+# Route workspaces 6-10 to the HDMI monitor when available
+workspace=6,monitor:HDMI-A-1
+workspace=7,monitor:HDMI-A-1
+workspace=8,monitor:HDMI-A-1
+workspace=9,monitor:HDMI-A-1
+workspace=10,monitor:HDMI-A-1


### PR DESCRIPTION
## Summary
- position HDMI monitor to the right of the built-in display on the laptop
- map workspaces 6-10 to the HDMI monitor when it is connected
- document the laptop's HDMI monitor setup

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check -L --accept-flake-config` *(failed: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_686531b5160483318502e0515d50a671