### PR TITLE
Add overlay for rtl88x2bu driver

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,7 +65,7 @@
         desktop = nixpkgs.lib.nixosSystem rec {
           system = "x86_64-linux";
           specialArgs = {
-            inherit inputs;
+            inherit inputs desktopPorts;
             pkgs-stable = import nixpkgs-stable {
               inherit system;
               config.allowUnfree = true;
@@ -75,7 +75,7 @@
               config.allowUnfree = true;
             };
           };
-          modules = commonModules ++ [ (import ./hosts/desktop { inherit desktopPorts; }) ];
+          modules = commonModules ++ [ ./hosts/desktop ];
         };
       };
     };

--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -1,4 +1,4 @@
-{ desktopPorts ? import ./ports.nix, ... }:
+{ config, pkgs, desktopPorts ? import ./ports.nix, ... }:
 {
   imports = [
     ../../hardware-configuration-desktop.nix
@@ -8,7 +8,6 @@
 
   nixpkgs.overlays = [ (import ../../rtl88x2bu-overlay.nix) ];
 
-  boot.kernelPackages = pkgs.linuxPackages_zen;
   boot.extraModulePackages = [ config.boot.kernelPackages.rtl88x2bu ];
   boot.kernelModules = [ "88x2bu" ];
   boot.blacklistedKernelModules = [ "rtl8xxxu" ];

--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -6,6 +6,13 @@
     ../../packages/desktop.nix
   ];
 
+  nixpkgs.overlays = [ (import ../../rtl88x2bu-overlay.nix) ];
+
+  boot.kernelPackages = pkgs.linuxPackages_zen;
+  boot.extraModulePackages = [ config.boot.kernelPackages.rtl88x2bu ];
+  boot.kernelModules = [ "88x2bu" ];
+  boot.blacklistedKernelModules = [ "rtl8xxxu" ];
+
   networking.firewall = {
     allowedTCPPorts = desktopPorts;
     allowedUDPPorts = desktopPorts;

--- a/rtl88x2bu-overlay.nix
+++ b/rtl88x2bu-overlay.nix
@@ -1,15 +1,17 @@
 self: super: {
-  rtl88x2bu = super.rtl88x2bu.overrideAttrs (old: {
-    src = super.fetchFromGitHub {
-      owner = "RinCat";
-      repo = "RTL88x2BU-Linux-Driver";
-      # commit with kernel >=6.15 patches
-      rev = "77a82dbac7192bb49fa87458561b0f2455cdc88f";
-      sha256 = "1qrhd4698808axm6mliq810s3yj8aj7nv890pdvpbir8nvn6c44h";
-    };
-    # ensure sources compile with kbuild
-    prePatch = (old.prePatch or "") + ''
-      sed -i 's|-I\\$(src)/include|-I\\$(PWD)/include|' Makefile
-    '';
+  linuxPackagesFor = kernel: let
+    base = super.linuxPackagesFor kernel;
+  in base.extend (final: prev: {
+    rtl88x2bu = prev.rtl88x2bu.overrideAttrs (old: {
+      src = super.fetchFromGitHub {
+        owner = "RinCat";
+        repo = "RTL88x2BU-Linux-Driver";
+        rev = "77a82dbac7192bb49fa87458561b0f2455cdc88f"; # commit with 6.15 patches
+        sha256 = "1qrhd4698808axm6mliq810s3yj8aj7nv890pdvpbir8nvn6c44h";
+      };
+      prePatch = (old.prePatch or "") + ''
+        sed -i 's|-I\\$(src)/include|-I\\$(PWD)/include|' Makefile
+      '';
+    });
   });
 }

--- a/rtl88x2bu-overlay.nix
+++ b/rtl88x2bu-overlay.nix
@@ -3,8 +3,13 @@ self: super: {
     src = super.fetchFromGitHub {
       owner = "RinCat";
       repo = "RTL88x2BU-Linux-Driver";
-      rev = "master"; # or a specific tag compatible with kernel >=6.15
+      # commit with kernel >=6.15 patches
+      rev = "77a82dbac7192bb49fa87458561b0f2455cdc88f";
       sha256 = "1qrhd4698808axm6mliq810s3yj8aj7nv890pdvpbir8nvn6c44h";
     };
+    # ensure sources compile with kbuild
+    prePatch = (old.prePatch or "") + ''
+      substituteInPlace Makefile --replace "-I$(src)/include" "-I$(PWD)/include"
+    '';
   });
 }

--- a/rtl88x2bu-overlay.nix
+++ b/rtl88x2bu-overlay.nix
@@ -1,0 +1,10 @@
+self: super: {
+  rtl88x2bu = super.rtl88x2bu.overrideAttrs (old: {
+    src = super.fetchFromGitHub {
+      owner = "RinCat";
+      repo = "RTL88x2BU-Linux-Driver";
+      rev = "master"; # or a specific tag compatible with kernel >=6.15
+      sha256 = "1qrhd4698808axm6mliq810s3yj8aj7nv890pdvpbir8nvn6c44h";
+    };
+  });
+}

--- a/rtl88x2bu-overlay.nix
+++ b/rtl88x2bu-overlay.nix
@@ -9,7 +9,7 @@ self: super: {
     };
     # ensure sources compile with kbuild
     prePatch = (old.prePatch or "") + ''
-      substituteInPlace Makefile --replace '-I\$(src)/include' '-I\$(PWD)/include'
+      sed -i 's|-I\\$(src)/include|-I\\$(PWD)/include|' Makefile
     '';
   });
 }

--- a/rtl88x2bu-overlay.nix
+++ b/rtl88x2bu-overlay.nix
@@ -9,7 +9,7 @@ self: super: {
     };
     # ensure sources compile with kbuild
     prePatch = (old.prePatch or "") + ''
-      substituteInPlace Makefile --replace "-I$(src)/include" "-I$(PWD)/include"
+      substituteInPlace Makefile --replace '-I\$(src)/include' '-I\$(PWD)/include'
     '';
   });
 }


### PR DESCRIPTION
## Summary
- add an overlay fetching RinCat/RTL88x2BU-Linux-Driver
- enable this overlay and module for the desktop host

## Testing
- `nix flake check` *(fails: undefined variable `config`)*

------
https://chatgpt.com/codex/tasks/task_e_68691cbf1d8c8331a9d279d3f250c9da