### PR TITLE
Add Realtek RTL8188GU WiFi driver

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -73,8 +73,8 @@
 
   # Configure the kernel and add custom kernel modules.
   boot.kernelPackages = pkgs.linuxPackages_zen;
-  boot.kernelModules = [ "v4l2loopback" ];
-  boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
+  boot.kernelModules = [ "v4l2loopback" "8188eu" ];
+  boot.extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback pkgs.rtl8188eus-aircrack ];
   boot.extraModprobeConfig = ''
     # Configure v4l2loopback: virtual camera settings for apps like Skype, Zoom, and Teams.
     options v4l2loopback video_nr=0,1 exclusive_caps=1,1 card_label="Virtual Camera 0","OBS Camera"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,9 +25,9 @@ This file is the heart of the system configuration. Key areas include:
 
 1. **Imports** – brings in other modules such as custom packages from `packages/common.nix`.
 2. **Hardware & Virtualization** – enables virtualbox, libvirtd, Logitech device support, and other hardware options. ZRAM swap is also activated. Bluetooth is enabled only for the laptop host. Additional udev rules grant Wolf virtual input devices access to `/dev/uinput` and place them on seat9.
-3. **Boot Settings** – systemd-boot with EFI support, kernel modules (e.g., `v4l2loopback`), and plymouth splash.
+3. **Boot Settings** – systemd-boot with EFI support, kernel modules (e.g., `v4l2loopback` and `8188eu` for the Realtek RTL8188GU adapter), and plymouth splash.
 4. **Security** – enabling policykit and realtime kit.
-5. **Networking** – hostname, firewall defaults, wireless support, and NetworkManager.
+5. **Networking** – hostname, firewall defaults, wireless support, usb-modeswitch to toggle Wi‑Fi adapters, and NetworkManager.
 6. **Locale & Time** – timezone `Europe/Paris` with English locales.
 7. **Console and X11** – keeps the French keyboard layout while the system language is English.
 8. **Fonts** – installs a selection of fonts including JetBrains Mono and Noto packages.

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -122,6 +122,7 @@ let
     wirelesstools         # Tools for managing wireless interfaces
     docker-compose        # Define and run multi-container Docker applications
     wavemon              # Network analysis tool (verify details online)
+    usb-modeswitch        # Switch devices like the RTL8188GU from CDROM mode
   ];
 
   # 2.15: Browsers & Internet Utilities


### PR DESCRIPTION
## Summary
- load the rtl8188eu kernel module at boot
- include rtl8188eus-aircrack module package
- install usb-modeswitch
- document the added driver and package

## Testing
- `nix flake check` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68697822c9a0833181ef7b2d2f059085