### PR TITLE
Add custom opacity rules and update screenshot workflow

### DIFF
--- a/hyprland.base.conf
+++ b/hyprland.base.conf
@@ -63,6 +63,11 @@ decoration {
         color = rgba(0,0,0,.5)
     }
 }
+windowrule = opacity 0.95 override 0.95 override,title:.*YouTube.*
+windowrule = opacity 0.95 override 0.95 override,class:steam_app_975370
+windowrule = opacity 1.0 override 1.0 override,class:gambatte_speedrun.exe
+windowrule = opacity 0.95 override 0.95 override,initialTitle:.*Discord Popout.*
+
 
 animations {
     enabled = true
@@ -134,7 +139,8 @@ bind = $mainMod, F,fullscreen
 bind = $mainMod, M, exec, hyprpanel toggleWindow settings-dialog
 bind = $mainMod, B, exec, hyprpanel toggleWindow bar-1
 bind = $mainMod, X, exec, hyprlock
-bind = ,print, exec, grimblast --freeze save area - | swappy -f -
+bind = ,print, exec, grimblast --freeze copy area
+# bind = ,print, exec, grimblast --freeze save area - | swappy -f -
 bind=, XF86AudioRaiseVolume, exec, pamixer -i 5
 bind=, XF86AudioLowerVolume, exec, pamixer -d 5
 bind =, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -200,6 +200,7 @@ let
     inputs.hyprland-contrib.packages.${pkgs.system}.grimblast
     swappy              # Alternative screenshot tool
     swaybg                # Wallpaper setter for Wayland compositors
+    ksnip
   ];
 
   # 2.26: Brightness Control Utilities


### PR DESCRIPTION
- Introduced specific window opacity rules for YouTube, Steam, Discord Popout, and Gambatte for improved visual clarity.
- Changed the print screen keybinding to copy screenshots directly to clipboard instead of opening with Swappy.
- Commented out the previous screenshot handling command for possible future reuse.
- Added `ksnip` to system packages for enhanced screenshot editing capabilities.