### PR TITLE
Update virtualization setup, add QuickEMU, steam-run, and PiP rule

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -42,13 +42,11 @@
 
   # virtualisation.docker.enable = true;
 
-  # VirtualBox host support and group membership for desktop user.
-  virtualisation.virtualbox.host.enable = true;
-  users.extraGroups.vboxusers.members = [ "desktop" ];
-
   # Enable libvirt for virtualization management and virt-manager as the GUI.
+  # Also add UEFI firmware support
   virtualisation.libvirtd.enable = true;
   programs.virt-manager.enable = true;
+  systemd.tmpfiles.rules = [ "L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware" ];
 
   # Enable Logitech wireless devices with both CLI and graphical tools.
   hardware.logitech.wireless.enable = true;
@@ -106,8 +104,8 @@
   networking.firewall.checkReversePath = "loose";
 
   # Enable wireless support (wpa_supplicant will be used).
-  networking.wireless.enable = true;
-  networking.wireless.userControlled.enable = true;
+  # networking.wireless.enable = true;
+  # networking.wireless.userControlled.enable = true;
 
   # Enable NetworkManager for easier network management.
   networking.networkmanager.enable = true;

--- a/hyprland.base.conf
+++ b/hyprland.base.conf
@@ -67,6 +67,7 @@ windowrule = opacity 0.95 override 0.95 override,title:.*YouTube.*
 windowrule = opacity 0.95 override 0.95 override,class:steam_app_975370
 windowrule = opacity 1.0 override 1.0 override,class:gambatte_speedrun.exe
 windowrule = opacity 0.95 override 0.95 override,initialTitle:.*Discord Popout.*
+windowrule = opacity 0.95 override 0.95 override,initialTitle:.*Picture-in-Picture.*
 
 
 animations {

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -230,6 +230,7 @@ let
     xorg.xwininfo         # Display information about X windows
     yad                   # Yet Another Dialog for X (GUI dialogs)
     steamtinkerlaunch     # Tool to tweak Steam launch options
+    steam-run             # Run programs in FHS environment
   ];
 
 in

--- a/packages/desktop.nix
+++ b/packages/desktop.nix
@@ -12,9 +12,18 @@ let
   pkgs3_2 = with pkgs; [
     davinci-resolve     # Professional video editor
   ];
+
+  # 3.2: Virtualization
+  pkgs3_3 = with pkgs; [
+    qemu
+    quickemu
+    quickgui
+  ];
+
 in
 {
   environment.systemPackages =
     pkgs3_1 ++
-    pkgs3_2;
+    pkgs3_2 ++
+    pkgs3_3;
 }


### PR DESCRIPTION
- Removed VirtualBox host support; switched to libvirt with virt-manager.
- Added systemd tmpfiles rule for QEMU UEFI firmware in `configuration.nix`.
- Commented out manual wireless options in favor of NetworkManager.
- Added `windowrule` for Picture-in-Picture in `hyprland.base.conf`.
- Included `steam-run` in `packages/common.nix` for FHS environment.
- Created `pkgs3_3` with QEMU tooling (`qemu`, `quickemu`, `quickgui`) and merged into `environment.systemPackages`.