### PR TITLE
Add desktop alias for Valheim

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -67,6 +67,7 @@ The shared Zsh module (`hm/zsh.nix`) defines several handy shortcuts:
 | `dpms`              | `hyprctl dispatch dpms off && sleep 2 && hyprctl dispatch dpms on` |
 | `4000`              | `hyprctl hyprsunset temperature 40000` |
 | `identity`          | `hyprctl hyprsunset identity` |
+| `valheim`           | `gamemoderun mangohud steam-run /home/desktop/.steam/steam/steamapps/common/Valheim/start_game_bepinex.sh` |
 
 On the laptop host, additional aliases are defined in `home-laptop.nix`:
 

--- a/home-desktop.nix
+++ b/home-desktop.nix
@@ -50,6 +50,10 @@
     ./wm-desktop/wm.nix
   ];
   services.syncthing.enable = true;
+
+  programs.zsh.shellAliases = {
+    valheim = "gamemoderun mangohud steam-run /home/desktop/.steam/steam/steamapps/common/Valheim/start_game_bepinex.sh";
+  };
   
   # Obs Studio
   programs.obs-studio.enable = true;


### PR DESCRIPTION
## Summary
- add a `valheim` alias on the desktop host
- document the new alias in CONFIGURATION.md

## Testing
- `nix flake check` *(fails: interrupted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6878d2d9cfdc8331bd58d117be8ac662