### PR TITLE
feat(desktop): add sgdboop package for Steam artwork management

### DIFF
--- a/packages/desktop.nix
+++ b/packages/desktop.nix
@@ -3,14 +3,14 @@
 let
   # 3.1: Digital Audio Workstations (DAWs)
   pkgs3_1 = with pkgs; [
-    reaper              # Main DAW application
-    yabridge            # Bridges Windows plugins
-    yabridgectl         # CLI helper for yabridge
+    reaper # Main DAW application
+    yabridge # Bridges Windows plugins
+    yabridgectl # CLI helper for yabridge
   ];
 
   # 3.2: Video Editing
   pkgs3_2 = with pkgs; [
-    davinci-resolve     # Professional video editor
+    davinci-resolve # Professional video editor
   ];
 
   # 3.3: Virtualization
@@ -26,11 +26,12 @@ let
     phoronix-test-suite
   ];
 
+  # 3.5: Steam utilities
+  pkgs3_5 = with pkgs; [
+    sgdboop # Steam artwork manager
+  ];
+
 in
 {
-  environment.systemPackages =
-    pkgs3_1 ++
-    pkgs3_2 ++
-    pkgs3_3 ++
-    pkgs3_4;
+  environment.systemPackages = pkgs3_1 ++ pkgs3_2 ++ pkgs3_3 ++ pkgs3_4 ++ pkgs3_5;
 }


### PR DESCRIPTION
## Summary
- group sgdboop under new Steam utilities in desktop packages
- keep desktop home profile unchanged by removing sgdboop

## Testing
- `nix --extra-experimental-features "nix-command flakes" fmt packages/desktop.nix home-desktop.nix` *(fails: flake 'git+file:///workspace/nixos' does not provide attribute 'formatter.x86_64-linux')*
- `nix --extra-experimental-features "nix-command flakes" flake check --no-build` *(fails: path '/nix/store/93bnfqlr0awg02cvrv93mx53aywgvnj3-base16-schemes-0-unstable-2025-06-04.drv' is not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdc0106b48331bfba33451c5ea572