### PR TITLE
docs: document repo layout and host usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # NixOS Configuration
 
+The repository is organized into key directories: `hosts/` defines the `desktop` and `laptop` machines, while `packages/` and `overlays/` provide custom packages and overlay tweaks. Reference hosts by name in flake commands, for example:
+
+```sh
+sudo nixos-rebuild switch --flake .#desktop
+nix flake show .#nixosConfigurations.laptop
+```
+
 This repository contains the NixOS configuration for both a desktop and a laptop setup. For a full description of the available modules and options see [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
 
 ## Getting Started


### PR DESCRIPTION
## Summary
- describe key directories such as `hosts`, `packages`, and `overlays`
- show how to reference `desktop` and `laptop` hosts in flake-enabled commands

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake show`
- `nix --extra-experimental-features 'nix-command flakes' flake check --no-build --show-trace` *(fails: path '/nix/store/93bnfqlr0awg02cvrv93mx53aywgvnj3-base16-schemes-0-unstable-2025-06-04.drv' is not valid)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdf29ad8083319908f2c540a87a6b