### PR TITLE
Optimize host-specific virtualization and swap behaviour

### DIFF
--- a/common-modules.nix
+++ b/common-modules.nix
@@ -3,8 +3,8 @@ with inputs; [
   stylix.nixosModules.stylix
   ./configuration.nix
   home-manager.nixosModules.home-manager
-  { home-manager.useGlobalPkgs = false;
+  {
+    home-manager.useGlobalPkgs = false;
     home-manager.useUserPackages = true;
   }
-  { virtualisation.docker.enable = true; }
 ]

--- a/configuration.nix
+++ b/configuration.nix
@@ -30,24 +30,18 @@
   # Import additional NixOS configuration files and package definitions.
   imports =
     [
-      ./packages/common.nix    # Common package definitions
+      ./packages/common.nix # Common package definitions
       #  ./python.nix      # Python-specific configurations
     ];
 
   ######################################
   # 2. Hardware & Virtualization Settings
   ######################################
-  #zSwap
-  zramSwap.enable = true;
-
-
-  # virtualisation.docker.enable = true;
-
-  # Enable libvirt for virtualization management and virt-manager as the GUI.
-  # Also add UEFI firmware support
-  virtualisation.libvirtd.enable = true;
-  programs.virt-manager.enable = true;
-  systemd.tmpfiles.rules = [ "L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware" ];
+  # zSwap
+  zramSwap = {
+    enable = true;
+    priority = 100;
+  };
 
   # Enable Logitech wireless devices with both CLI and graphical tools.
   hardware.logitech.wireless.enable = true;
@@ -126,7 +120,7 @@
   systemd.services."NetworkManager-wait-online".enable = false;
 
 
-  networking.enableIPv6  = false;
+  networking.enableIPv6 = false;
   ##############################
   # 6. Time & Internationalization
   ##############################
@@ -136,15 +130,15 @@
   # Set default locale to English while keeping the keyboard layout in French.
   i18n.defaultLocale = "en_US.UTF-8";
   i18n.extraLocaleSettings = {
-    LC_ADDRESS       = "en_US.UTF-8";
+    LC_ADDRESS = "en_US.UTF-8";
     LC_IDENTIFICATION = "en_US.UTF-8";
-    LC_MEASUREMENT   = "en_US.UTF-8";
-    LC_MONETARY      = "en_US.UTF-8";
-    LC_NAME          = "en_US.UTF-8";
-    LC_NUMERIC       = "en_US.UTF-8";
-    LC_PAPER         = "en_US.UTF-8";
-    LC_TELEPHONE     = "en_US.UTF-8";
-    LC_TIME          = "en_US.UTF-8";
+    LC_MEASUREMENT = "en_US.UTF-8";
+    LC_MONETARY = "en_US.UTF-8";
+    LC_NAME = "en_US.UTF-8";
+    LC_NUMERIC = "en_US.UTF-8";
+    LC_PAPER = "en_US.UTF-8";
+    LC_TELEPHONE = "en_US.UTF-8";
+    LC_TIME = "en_US.UTF-8";
   };
 
   ##############################
@@ -152,7 +146,7 @@
   ##############################
   # Configure X11 keymap.
   services.xserver = {
-    xkb.layout = "fr";  # Set keyboard layout to French.
+    xkb.layout = "fr"; # Set keyboard layout to French.
     xkb.variant = "";
   };
 
@@ -160,8 +154,8 @@
   console.keyMap = "fr";
   console = {
     earlySetup = true;
-    packages = with pkgs; [ terminus_font ];  # Use Terminus font during early boot.
-    font = "ter-u32n";  # Set console font.
+    packages = with pkgs; [ terminus_font ]; # Use Terminus font during early boot.
+    font = "ter-u32n"; # Set console font.
   };
 
   ##############################
@@ -170,11 +164,11 @@
   # Install and configure system fonts.
   fonts = {
     packages = with pkgs; [
-      noto-fonts          # General purpose fonts.
-      noto-fonts-emoji    # Emoji support.
-      meslo-lgs-nf        # Monospaced font.
-      corefonts         # Basic core fonts.
-      nerd-fonts.jetbrains-mono  # JetBrains Mono with extra glyphs.
+      noto-fonts # General purpose fonts.
+      noto-fonts-emoji # Emoji support.
+      meslo-lgs-nf # Monospaced font.
+      corefonts # Basic core fonts.
+      nerd-fonts.jetbrains-mono # JetBrains Mono with extra glyphs.
     ];
     fontconfig = {
       # Enable antialiasing to improve font rendering.
@@ -246,7 +240,7 @@
   ##############################
   # Set global environment variables.
   environment.variables = {
-    QT_QPA_PLATFORM = "wayland;xcb";  # Allow Qt apps to use Wayland with fallback to X.
+    QT_QPA_PLATFORM = "wayland;xcb"; # Allow Qt apps to use Wayland with fallback to X.
   };
   environment.sessionVariables.NIXOS_OZONE_WL = "1";
 
@@ -381,7 +375,7 @@
   ##############################
   # Configure Stylix for theming and desktop customization.
   stylix.enable = true;
-  stylix.image = ./hm/wallpaper/wall3.png;  # Set the desktop wallpaper.
+  stylix.image = ./hm/wallpaper/wall3.png; # Set the desktop wallpaper.
   stylix.base16Scheme = "${pkgs.base16-schemes}/share/themes/catppuccin-latte.yaml";
   stylix.homeManagerIntegration.followSystem = true;
   stylix.targets.qt.platform = lib.mkForce "qtct";
@@ -413,5 +407,5 @@
   # 18. Final System State Version
   ##############################
   # Set the state version for NixOS. This should remain unchanged unless you understand the implications.
-  system.stateVersion = "23.05";  # Did you read the comment?
+  system.stateVersion = "23.05"; # Did you read the comment?
 }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,16 +14,16 @@ Each configuration pulls in common modules like `configuration.nix`, GPU configu
 
 The shared pieces are defined in `common-modules.nix`. This file imports the
 main `configuration.nix`, the Stylix theming module and the Home Manager NixOS
-module with `useGlobalPkgs` disabled and `useUserPackages` enabled. It also sets
-`virtualisation.docker.enable = true`. Both hosts include this list of modules via the flake so
-they start from the same base configuration.
+module with `useGlobalPkgs` disabled and `useUserPackages` enabled. Docker is
+now configured per-host so the common modules remain minimal and both hosts
+start from the same base configuration.
 
 ## Core System Configuration (`configuration.nix`)
 
 This file is the heart of the system configuration. Key areas include:
 
 1. **Imports** – brings in other modules such as custom packages from `packages/common.nix`.
-2. **Hardware & Virtualization** – enables virtualbox, libvirtd, Logitech device support, and other hardware options. ZRAM swap is also activated. Bluetooth is enabled only for the laptop host. Additional udev rules grant Wolf virtual input devices access to `/dev/uinput` and place them on seat9.
+2. **Hardware & Virtualization** – enables virtualbox, Logitech device support, and other hardware options. ZRAM swap is activated with a higher priority than disk-based swap. Docker and libvirtd are enabled only on the desktop host. Bluetooth is enabled only for the laptop host. Additional udev rules grant Wolf virtual input devices access to `/dev/uinput` and place them on seat9.
 3. **Boot Settings** – systemd-boot with EFI support, kernel modules (e.g., `v4l2loopback`), and plymouth splash.
 4. **Security** – enabling policykit and realtime kit.
 5. **Networking** – hostname, firewall defaults, wireless support, and NetworkManager.
@@ -120,12 +120,14 @@ machine‑specific options. Below is a summary of the two provided hosts:
     8501, 8777, 9100, 2268, 47984, 47989, 47998, 47999,
     48010, 48100, 48200, 47990, 48000, 48002, 8989, 8096, 8211, 27015.
   - The SSH daemon listens on port 2268.
+  - Runs Docker and libvirtd for virtualization and sets `vm.swappiness` to 60.
 
 - **laptop**
   - Imports `hardware-configuration-laptop.nix` with both AMD and NVIDIA GPU
     modules.
   - Enables Bluetooth (with the Blueman applet) so the service starts automatically, and provides a 16 GiB swap
     file at `/var/lib/swapfile`.
+  - Sets `vm.swappiness` to 20 and leaves Docker and libvirtd disabled.
   - Allows a small set of firewall ports: 80, 91, 443, 444, 8501 and 9100.
 
 ## Additional Modules

--- a/hardware-configuration-desktop.nix
+++ b/hardware-configuration-desktop.nix
@@ -5,7 +5,8 @@
 
 {
   imports =
-    [ (modulesPath + "/installer/scan/not-detected.nix")
+    [
+      (modulesPath + "/installer/scan/not-detected.nix")
     ];
 
   boot.initrd.availableKernelModules = [ "nvme" "xhci_pci" "ahci" "usbhid" "usb_storage" "sd_mod" ];
@@ -14,20 +15,23 @@
   boot.extraModulePackages = [ ];
 
   fileSystems."/" =
-    { device = "/dev/disk/by-uuid/b31e7c6e-d7cd-4acd-ab3b-8f6c51887833";
+    {
+      device = "/dev/disk/by-uuid/b31e7c6e-d7cd-4acd-ab3b-8f6c51887833";
       fsType = "ext4";
     };
 
   boot.initrd.luks.devices."nvme0n1p1_crypt".device = "/dev/disk/by-uuid/48dbe212-3270-48eb-bd63-fafe9fb40a11";
 
   fileSystems."/boot" =
-    { device = "/dev/disk/by-uuid/2B27-5D0E";
+    {
+      device = "/dev/disk/by-uuid/2B27-5D0E";
       fsType = "vfat";
       options = [ "fmask=0077" "dmask=0077" ];
     };
 
   fileSystems."/mnt/storage" =
-    { device = "/dev/disk/by-uuid/323ce481-302f-4675-89a9-ca0b1971d8f2";
+    {
+      device = "/dev/disk/by-uuid/323ce481-302f-4675-89a9-ca0b1971d8f2";
       fsType = "ext4";
     };
 
@@ -39,18 +43,19 @@
   # boot.initrd.luks.devices."luks-b636108b-c002-4241-8490-8d7f2b45ba0a".device = "/dev/disk/by-uuid/b636108b-c002-4241-8490-8d7f2b45ba0a";
 
   fileSystems."/mnt/4to" =
-    { device = "/dev/disk/by-uuid/8500bd1f-2304-4981-b32e-a2f4560a2597";
+    {
+      device = "/dev/disk/by-uuid/8500bd1f-2304-4981-b32e-a2f4560a2597";
       fsType = "ext4";
     };
 
   fileSystems."/mnt/ssd" =
-    { device = "/dev/disk/by-uuid/D0CE962DCE960C3A";
+    {
+      device = "/dev/disk/by-uuid/D0CE962DCE960C3A";
       fsType = "ntfs-3g";
     };
 
   swapDevices =
-    [ { device = "/dev/disk/by-uuid/4dd6a497-7d5f-45f9-b8f8-8390a9080d3f"; }
-    ];
+    [{ device = "/dev/disk/by-uuid/4dd6a497-7d5f-45f9-b8f8-8390a9080d3f"; priority = 0; }];
 
   # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
   # (the default) this is the recommended approach. When using systemd-networkd it's

--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -24,6 +24,14 @@
 
   nix.settings.trusted-users = [ "desktop" ];
 
+  virtualisation.docker.enable = true;
+  virtualisation.libvirtd.enable = true;
+  programs.virt-manager.enable = true;
+  systemd.tmpfiles.rules = [
+    "L+ /var/lib/qemu/firmware - - - - ${pkgs.qemu}/share/qemu/firmware"
+  ];
+  boot.kernel.sysctl."vm.swappiness" = 60;
+
   services.displayManager = {
     sddm.enable = true;
     autoLogin.enable = true;

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -18,8 +18,10 @@
   services.blueman.enable = true;
   swapDevices = [{
     device = "/var/lib/swapfile";
-    size = 16*1024;
+    size = 16 * 1024;
+    priority = 0;
   }];
+  boot.kernel.sysctl."vm.swappiness" = 20;
 
   home-manager.users.laptop = import ../../home-laptop.nix;
   nix.settings.trusted-users = [ "laptop" ];


### PR DESCRIPTION
## Summary
- enable Docker and libvirtd only on desktop
- prioritize zram swap over disk swap and tune swappiness per host
- document virtualization and swap differences between desktop and laptop

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake show`
- `nix --extra-experimental-features 'nix-command flakes' flake check --no-build` *(fails: path '/nix/store/s1lgp5bxfb8ps9z094mbnq1i4bcm3wlz-base16-schemes-0-unstable-2025-06-04.drv' is not valid)*
- `nixos-rebuild dry-activate --flake .#desktop` *(fails: command not found: nixos-rebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68c15e934c188331a1c470e392381489