### PR TITLE
Disable Caps Lock and update rtl8852cu driver hash

### DIFF
--- a/hm/doom/config.el
+++ b/hm/doom/config.el
@@ -209,3 +209,6 @@
   (setq org-agenda-files
         (find-lisp-find-files (expand-file-name "~/Documents/business/org/")
                               "\\.org$")))
+
+;; Ignore complètement la touche "sans symbole" que XKB envoie
+(global-set-key (kbd "<void-symbol>") #'ignore)

--- a/hosts/laptop/default.nix
+++ b/hosts/laptop/default.nix
@@ -36,4 +36,8 @@
   };
   services.desktopManager.plasma6.enable = true;
   services.displayManager.defaultSession = "hyprland";
+  services.udev.extraHwdb = ''
+    evdev:input:b*v*p*e*
+     KEYBOARD_KEY_3a=reserved
+  '';
 }

--- a/packages/rtl8852cu.nix
+++ b/packages/rtl8852cu.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation {
     owner = "morrownr";
     repo = "rtl8852cu-20240510";
     rev = "5705ed8cb5175fad819f073e11f2b6ff11ad6cea";
-    hash = "sha256-6JwRlpr4T7ahhFSw8vbrstDnaSF/QOIMB0mVtPckoF0=";
+    hash = "sha256-xjjUUZjju0sDp4M8cA7nJzZq2yPqwUwwNmUlHth2OzE=";
   };
 
   nativeBuildInputs = [ bc nukeReferences ] ++ kernel.moduleBuildDependencies;

--- a/wm-laptop/hyprland.conf
+++ b/wm-laptop/hyprland.conf
@@ -18,3 +18,6 @@ workspace=7,monitor:HDMI-A-1
 workspace=8,monitor:HDMI-A-1
 workspace=9,monitor:HDMI-A-1
 workspace=10,monitor:HDMI-A-1
+input {
+    kb_options = caps:none
+}


### PR DESCRIPTION
- Added Emacs keybinding to ignore `<void-symbol>` events from XKB.
- Introduced a udev hwdb rule mapping Caps Lock to `reserved`, disabling it globally.
- Updated rtl8852cu driver derivation with a new `sha256` hash for source integrity.
- Configured Hyprland to disable Caps Lock with `kb_options = caps:none`.