### PR TITLE
Update Home Manager git settings and centralize NixOS `system` in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,12 +43,12 @@
 
   outputs = inputs@{ self, nixpkgs, nixpkgs-stable, nixpkgs-unstable, home-manager, pipewire-screenaudio, stylix, zen-browser, ... }:
     let
+      system = "x86_64-linux";
       desktopPorts = import ./hosts/desktop/ports.nix;
       commonModules = import ./common-modules.nix { inherit inputs; };
     in {
       nixosConfigurations = {
-        laptop = nixpkgs.lib.nixosSystem rec {
-          system = "x86_64-linux";
+        laptop = nixpkgs.lib.nixosSystem {
           specialArgs = {
             inherit inputs;
             pkgs-stable = import nixpkgs-stable {
@@ -58,8 +58,7 @@
           };
           modules = commonModules ++ [ ./hosts/laptop ];
         };
-        desktop = nixpkgs.lib.nixosSystem rec {
-          system = "x86_64-linux";
+        desktop = nixpkgs.lib.nixosSystem {
           specialArgs = {
             inherit inputs;
             pkgs-stable = import nixpkgs-stable {

--- a/home-desktop.nix
+++ b/home-desktop.nix
@@ -51,8 +51,10 @@
   home.file.".config/doom/packages.el".source = ./hm/doom/packages.el;
   programs.git = {
     enable = true;
-    userName = "Alto";
-    userEmail = "lafon.ludovic.ll@proton.me";
+    settings.user = {
+      name = "Alto";
+      email = "lafon.ludovic.ll@proton.me";
+    };
   };
 
   imports = [

--- a/home-laptop.nix
+++ b/home-laptop.nix
@@ -51,8 +51,10 @@
   home.file.".config/doom/packages.el".source = ./hm/doom/packages.el;
   programs.git = {
     enable = true;
-    userName = "Alto";
-    userEmail = "lafon.ludovic.ll@proton.me";
+    settings.user = {
+      name = "Alto";
+      email = "lafon.ludovic.ll@proton.me";
+    };
   };
 
   imports = [


### PR DESCRIPTION
### Motivation
- Suppress evaluation warnings about renamed Home Manager git options by using the new option path.
- Avoid the deprecated per-`nixosSystem` `system` attribute and the related evaluation warning by centralizing the platform string.
- Keep flake outputs consistent by making the target platform reusable across imports.

### Description
- Replace `programs.git.userName`/`userEmail` with `programs.git.settings.user.name`/`email` in `home-desktop.nix` and `home-laptop.nix`.
- Add a top-level `system = "x86_64-linux"` binding in `flake.nix` and remove the per-`nixosSystem rec { system = ...; }` usage.
- Update `flake.nix` `nixosConfigurations` to use the centralized `system` when importing `nixpkgs-stable` and `nixpkgs-unstable`.
- Changes touch `flake.nix`, `home-desktop.nix`, and `home-laptop.nix`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d25b2aad0833182820db185567f3c)