### PR TITLE
Fix Home Manager git settings and set host platform in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,12 +43,12 @@
 
   outputs = inputs@{ self, nixpkgs, nixpkgs-stable, nixpkgs-unstable, home-manager, pipewire-screenaudio, stylix, zen-browser, ... }:
     let
+      system = "x86_64-linux";
       desktopPorts = import ./hosts/desktop/ports.nix;
       commonModules = import ./common-modules.nix { inherit inputs; };
     in {
       nixosConfigurations = {
-        laptop = nixpkgs.lib.nixosSystem rec {
-          system = "x86_64-linux";
+        laptop = nixpkgs.lib.nixosSystem {
           specialArgs = {
             inherit inputs;
             pkgs-stable = import nixpkgs-stable {
@@ -56,10 +56,12 @@
               config.allowUnfree = true;
             };
           };
-          modules = commonModules ++ [ ./hosts/laptop ];
+          modules = commonModules ++ [
+            { nixpkgs.hostPlatform = system; }
+            ./hosts/laptop
+          ];
         };
-        desktop = nixpkgs.lib.nixosSystem rec {
-          system = "x86_64-linux";
+        desktop = nixpkgs.lib.nixosSystem {
           specialArgs = {
             inherit inputs;
             pkgs-stable = import nixpkgs-stable {
@@ -71,7 +73,10 @@
               config.allowUnfree = true;
             };
           };
-          modules = commonModules ++ [ (import ./hosts/desktop { inherit desktopPorts; }) ];
+          modules = commonModules ++ [
+            { nixpkgs.hostPlatform = system; }
+            (import ./hosts/desktop { inherit desktopPorts; })
+          ];
         };
       };
     };

--- a/home-desktop.nix
+++ b/home-desktop.nix
@@ -51,8 +51,10 @@
   home.file.".config/doom/packages.el".source = ./hm/doom/packages.el;
   programs.git = {
     enable = true;
-    userName = "Alto";
-    userEmail = "lafon.ludovic.ll@proton.me";
+    settings.user = {
+      name = "Alto";
+      email = "lafon.ludovic.ll@proton.me";
+    };
   };
 
   imports = [

--- a/home-laptop.nix
+++ b/home-laptop.nix
@@ -51,8 +51,10 @@
   home.file.".config/doom/packages.el".source = ./hm/doom/packages.el;
   programs.git = {
     enable = true;
-    userName = "Alto";
-    userEmail = "lafon.ludovic.ll@proton.me";
+    settings.user = {
+      name = "Alto";
+      email = "lafon.ludovic.ll@proton.me";
+    };
   };
 
   imports = [


### PR DESCRIPTION
### Motivation

- Address deprecation warnings for Home Manager git options by moving to the new `programs.git.settings.user` attributes.
- Ensure a consistent host platform is provided to NixOS builds instead of relying on per-configuration `system` assignments.
- Centralize the `system` value in the flake to reduce evaluation warnings and make `pkgs-*` imports consistent.

### Description

- Replace `programs.git.userName` / `programs.git.userEmail` with `programs.git.settings.user = { name = ...; email = ...; }` in `home-desktop.nix` and `home-laptop.nix`.
- Add `system = "x86_64-linux"` in `flake.nix` and inject `{ nixpkgs.hostPlatform = system; }` into the `modules` lists for both `laptop` and `desktop` NixOS configurations.
- Update `pkgs-stable`/`pkgs-unstable` imports to `inherit system` from the shared `system` variable instead of per-`nixosSystem` `rec` assignments.

### Testing

- Searched the repository for deprecated `programs.git` options with `rg` to confirm replacements were applied, and the search succeeded.
- Attempted `nix flake show` to exercise the flake, which failed due to the `nix-command` experimental feature being disabled in the environment.
- No automated build or activation runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d36054ac083318c972a4fe1065ea9)