### PR TITLE
Set CPU governor to `performance` for desktop host

### DIFF
--- a/hosts/desktop/default.nix
+++ b/hosts/desktop/default.nix
@@ -32,6 +32,7 @@
   virtualisation.libvirtd.enable = true;
   programs.virt-manager.enable = true;
   boot.kernel.sysctl."vm.swappiness" = 60;
+  powerManagement.cpuFreqGovernor = "performance";
 
   services.displayManager = {
     sddm.enable = true;


### PR DESCRIPTION
### Motivation

- Ensure the desktop host uses the `performance` CPU governor to prioritize responsiveness for desktop/gaming workloads.
- Keep governor configuration localized to the desktop host definition for clear host-specific tuning.

### Description

- Added `powerManagement.cpuFreqGovernor = "performance";` to `hosts/desktop/default.nix` to set the CPU frequency governor for the desktop host.
- The new setting is placed alongside other host-level system settings (near `boot.kernel.sysctl."vm.swappiness"`).

### Testing

- Ran `nix fmt`, which failed due to the experimental Nix feature `nix-command` being disabled. 
- No other automated tests (e.g. `nix flake check` or `nixos-rebuild dry-activate`) were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d3625584c8331a2951e088ef79a9c)