### PR TITLE
feat(nixos): migrate Hyprland rules to new syntax, add Codex CLI flake, update Realtek drivers & screenshot stack

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -7,7 +7,7 @@
   # Udev rules to allow Wolf virtual input devices and TP-Link TXE70UH
   services.udev.extraRules = ''
     # Switch TP-Link TXE70UH from CD-ROM to Wi‑Fi mode
-    ATTR{idVendor}=="35bc", ATTR{idProduct}=="0102", RUN+="${lib.getExe pkgs.usb-modeswitch} -K -v 35bc -p 0102"
+    ATTR{idVendor}=="0bda", ATTR{idProduct}=="1a2b", RUN+="${lib.getExe pkgs.usb-modeswitch} -K -v 0bda -p 1a2b"
 
     # Allows Wolf to access /dev/uinput
     KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0660", GROUP="input", OPTIONS+="static_node=uinput"

--- a/configuration.nix
+++ b/configuration.nix
@@ -179,6 +179,8 @@
       meslo-lgs-nf # Monospaced font.
       corefonts # Basic core fonts.
       nerd-fonts.jetbrains-mono # JetBrains Mono with extra glyphs.
+      dejavu_fonts
+      liberation_ttf
     ];
     fontconfig = {
       # Enable antialiasing to improve font rendering.

--- a/flake.lock
+++ b/flake.lock
@@ -197,26 +197,6 @@
         "type": "github"
       }
     },
-    "hyprland-contrib": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768426687,
-        "narHash": "sha256-CopNx3j//gZ2mE0ggEK9dZ474UcbDhpTw+KMor8mSxI=",
-        "owner": "hyprwm",
-        "repo": "contrib",
-        "rev": "541628cebe42792ddf5063c4abd6402c2f1bd68f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "contrib",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770843696,
@@ -360,7 +340,6 @@
       "inputs": {
         "codex-cli-nix": "codex-cli-nix",
         "home-manager": "home-manager",
-        "hyprland-contrib": "hyprland-contrib",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",

--- a/flake.lock
+++ b/flake.lock
@@ -147,11 +147,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768068402,
-        "narHash": "sha256-bAXnnJZKJiF7Xr6eNW6+PhBf1lg2P1aFUO9+xgWkXfA=",
+        "lastModified": 1769187349,
+        "narHash": "sha256-clG+nT6I2qxjIgk5WoSDKJyNhzKJs9jzbCujPF2S/yg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8bc5473b6bc2b6e1529a9c4040411e1199c43b4c",
+        "rev": "082a4cd87c6089d1d9c58ebe52655f9e07245fcb",
         "type": "github"
       },
       "original": {
@@ -167,11 +167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766066098,
-        "narHash": "sha256-d3HmUbmfTDIt9mXEHszqyo2byqQMoyJtUJCZ9U1IqHQ=",
+        "lastModified": 1768426687,
+        "narHash": "sha256-CopNx3j//gZ2mE0ggEK9dZ474UcbDhpTw+KMor8mSxI=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "41dbcac8183bb1b3a4ade0d8276b2f2df6ae4690",
+        "rev": "541628cebe42792ddf5063c4abd6402c2f1bd68f",
         "type": "github"
       },
       "original": {
@@ -182,11 +182,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1769018530,
+        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
         "type": "github"
       },
       "original": {
@@ -198,11 +198,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1767799921,
-        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
+        "lastModified": 1769089682,
+        "narHash": "sha256-9yA/LIuAVQq0lXelrZPjLuLVuZdm03p8tfmHhnDIkms=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
+        "rev": "078d69f03934859a181e81ba987c2bb033eebfc5",
         "type": "github"
       },
       "original": {
@@ -214,11 +214,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1768032153,
-        "narHash": "sha256-6kD1MdY9fsE6FgSwdnx29hdH2UcBKs3/+JJleMShuJg=",
+        "lastModified": 1769188852,
+        "narHash": "sha256-aBAGyMum27K7cP5OR7BMioJOF3icquJMZDDgk6ZEg1A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3146c6aa9995e7351a398e17470e15305e6e18ff",
+        "rev": "a1bab9e494f5f4939442a57a58d0449a109593fe",
         "type": "github"
       },
       "original": {
@@ -334,11 +334,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1768075324,
-        "narHash": "sha256-m4IAAwRqlty7C7Htxt6HDJ/HGXrzLRoHoBaNczzXBdo=",
+        "lastModified": 1769202931,
+        "narHash": "sha256-4IZuCMjlWEtS6rVXozVXaJG6QADHVncXC29PLZr6ZB4=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "5b5f21c46ed0ef1f0089df66d8cd83c78da980e9",
+        "rev": "749285c90e3e35ebe0952c86838f3089abbc7939",
         "type": "github"
       },
       "original": {
@@ -450,11 +450,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767618227,
-        "narHash": "sha256-9+XVF47E9NCVs249SSsDtr7YdG/23/lCJmWAjQvOfqI=",
+        "lastModified": 1769228180,
+        "narHash": "sha256-94KY0JNjdd3CcSyKlHPCPswlqmUrWT6+MfOHektsdB8=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "1586e49b3908b058e221f11d843eb46392dba17b",
+        "rev": "ef1663c14b7c3c2b84bcf140232534be5a2a0257",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -68,6 +68,25 @@
         "type": "github"
       }
     },
+    "codex-cli-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1770927256,
+        "narHash": "sha256-R/RoNtWU8LHFUK5nGRIewLipM8Dgme9YNHLxzGIXDfM=",
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
+        "rev": "00619f4aa35f3c027a866ec7c51105ccbb49e3ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "codex-cli-nix",
+        "type": "github"
+      }
+    },
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
@@ -102,6 +121,24 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -147,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769187349,
-        "narHash": "sha256-clG+nT6I2qxjIgk5WoSDKJyNhzKJs9jzbCujPF2S/yg=",
+        "lastModified": 1769872935,
+        "narHash": "sha256-07HMIGQ/WJeAQJooA7Kkg1SDKxhAiV6eodvOwTX6WKI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "082a4cd87c6089d1d9c58ebe52655f9e07245fcb",
+        "rev": "f4ad5068ee8e89e4a7c2e963e10dd35cd77b37b7",
         "type": "github"
       },
       "original": {
@@ -182,27 +219,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1769018530,
-        "narHash": "sha256-MJ27Cy2NtBEV5tsK+YraYr2g851f3Fl1LpNHDzDX15c=",
+        "lastModified": 1770843696,
+        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88d3861acdd3d2f0e361767018218e51810df8a1",
+        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1769089682,
-        "narHash": "sha256-9yA/LIuAVQq0lXelrZPjLuLVuZdm03p8tfmHhnDIkms=",
+        "lastModified": 1769598131,
+        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "078d69f03934859a181e81ba987c2bb033eebfc5",
+        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
         "type": "github"
       },
       "original": {
@@ -214,11 +251,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1769188852,
-        "narHash": "sha256-aBAGyMum27K7cP5OR7BMioJOF3icquJMZDDgk6ZEg1A=",
+        "lastModified": 1769740369,
+        "narHash": "sha256-xKPyJoMoXfXpDM5DFDZDsi9PHArf2k5BJjvReYXoFpM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1bab9e494f5f4939442a57a58d0449a109593fe",
+        "rev": "6308c3b21396534d8aaeac46179c14c439a89b8a",
         "type": "github"
       },
       "original": {
@@ -229,6 +266,22 @@
       }
     },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1761114652,
         "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
@@ -244,7 +297,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1767767207,
         "narHash": "sha256-Mj3d3PfwltLmukFal5i3fFt27L6NiKXdBezC1EBuZs4=",
@@ -287,7 +340,7 @@
     },
     "pipewire-screenaudio": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1761605726,
@@ -305,9 +358,10 @@
     },
     "root": {
       "inputs": {
+        "codex-cli-nix": "codex-cli-nix",
         "home-manager": "home-manager",
         "hyprland-contrib": "hyprland-contrib",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "pipewire-screenaudio": "pipewire-screenaudio",
@@ -324,9 +378,9 @@
         "firefox-gnome-theme": "firefox-gnome-theme",
         "flake-parts": "flake-parts",
         "gnome-shell": "gnome-shell",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nur": "nur",
-        "systems": "systems",
+        "systems": "systems_2",
         "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
@@ -334,11 +388,11 @@
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1769202931,
-        "narHash": "sha256-4IZuCMjlWEtS6rVXozVXaJG6QADHVncXC29PLZr6ZB4=",
+        "lastModified": 1769888473,
+        "narHash": "sha256-4KWbaJwaYnZ60bFyTudZYAKskjr7Sa17R3/yh+oXS7w=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "749285c90e3e35ebe0952c86838f3089abbc7939",
+        "rev": "ae5c0239ae4f82a8c7e33ad8a456535d5a9ba813",
         "type": "github"
       },
       "original": {
@@ -348,6 +402,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -450,11 +519,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769228180,
-        "narHash": "sha256-94KY0JNjdd3CcSyKlHPCPswlqmUrWT6+MfOHektsdB8=",
+        "lastModified": 1769747637,
+        "narHash": "sha256-fRdj480sqW/a+APO6CmelZsa07BRAdEQLUjBQJuyQbU=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "ef1663c14b7c3c2b84bcf140232534be5a2a0257",
+        "rev": "09e429679b7cc175e71e2d25800bab66493c1c80",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     pipewire-screenaudio.url = "github:IceDBorn/pipewire-screenaudio";
+    codex-cli-nix.url = "github:sadjow/codex-cli-nix";
     stylix.url = "github:danth/stylix";
     zen-browser = {
       url = "github:youwen5/zen-browser-flake";

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,6 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    hyprland-contrib = {
-      url = "github:hyprwm/contrib";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";

--- a/hm/neovim.nix
+++ b/hm/neovim.nix
@@ -30,7 +30,7 @@
       ''
         nnoremap <F4> :NERDTreeToggle<CR>
       '';
-    extraLuaConfig =
+    initLua =
       ''
         require 'coc'
         vim.g.coq_settings = {auto_start = true}

--- a/hyprland.base.conf
+++ b/hyprland.base.conf
@@ -83,6 +83,13 @@ animations {
     animation = layers, 1, 2, snappy, popin 70%
 }
 
+# Avoid capturing the selection overlay/border in screenshots.
+layerrule {
+    name = no_anim_for_selection
+    no_anim = on
+    match:namespace = selection
+}
+
 misc {
     force_default_wallpaper = -1
     disable_hyprland_logo = true
@@ -137,8 +144,8 @@ bind = $mainMod, F,fullscreen
 bind = $mainMod, M, exec, hyprpanel toggleWindow settings-dialog
 bind = $mainMod, B, exec, hyprpanel toggleWindow bar-1
 bind = $mainMod, X, exec, hyprlock
-bind = ,print, exec, grimblast --freeze copy area
-# bind = ,print, exec, grimblast --freeze save area - | swappy -f -
+bind = ,print, exec, hyprshot -m region -z --clipboard-only
+bind = CTRL, print, exec, /home/desktop/Documents/nix-configuration/scripts/satty-shot.sh
 bind=, XF86AudioRaiseVolume, exec, pamixer -i 5
 bind=, XF86AudioLowerVolume, exec, pamixer -d 5
 bind =, XF86AudioMute, exec, wpctl set-mute @DEFAULT_AUDIO_SINK@ toggle

--- a/hyprland.base.conf
+++ b/hyprland.base.conf
@@ -63,12 +63,12 @@ decoration {
         color = rgba(0,0,0,.5)
     }
 }
-windowrulev2 = opacity 0.95 override 0.95 override,title:.*YouTube.*
-windowrulev2 = opacity 0.95 override 0.95 override,title:.*Twitch.*
-windowrulev2 = opacity 0.95 override 0.95 override,class:steam_app_975370
-windowrulev2 = opacity 1.0 override 1.0 override,class:gambatte_speedrun.exe
-windowrulev2 = opacity 0.95 override 0.95 override,initialTitle:.*Discord Popout.*
-windowrulev2 = opacity 0.95 override 0.95 override,initialTitle:.*Picture-in-Picture.*
+windowrule = opacity 0.95 override 0.95 override, match:title .*YouTube.*
+windowrule = opacity 0.95 override 0.95 override, match:title .*Twitch.*
+windowrule = opacity 0.95 override 0.95 override, match:class steam_app_975370
+windowrule = opacity 1.0 override 1.0 override, match:class gambatte_speedrun.exe
+windowrule = opacity 0.95 override 0.95 override, match:initial_title .*Discord Popout.*
+windowrule = opacity 0.95 override 0.95 override, match:initial_title .*Picture-in-Picture.*
 
 
 animations {
@@ -106,10 +106,10 @@ device {
     sensitivity = -0.5
 }
 
-# Example windowrule v2 (legacy v1 removed)
-# windowrulev2 = float, class:^(kitty)$
-# Example windowrule v2
-# windowrulev2 = float,class:^(kitty)$,title:^(kitty)$
+# Example windowrule (named props + effects)
+# windowrule = float on, match:class ^(kitty)$
+# Example windowrule with multiple props
+# windowrule = float on, match:class ^(kitty)$, match:title ^(kitty)$
 # See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
 
 
@@ -119,9 +119,9 @@ $mainMod = SUPER
 bind = $mainMod, semicolon, exec, /home/desktop/Documents/nix-configuration/mute-vesktop.sh toggle
 
 # Clipse clipbloard
-windowrulev2 = float, class:(clipse)
-windowrulev2 = size 622 652, class:(clipse)
-windowrulev2 = stayfocused, class:(clipse)
+windowrule = float on, match:class (clipse)
+windowrule = size 622 652, match:class (clipse)
+windowrule = stay_focused on, match:class (clipse)
 
 bind = SUPER, V, exec, kitty --class clipse -e clipse
 

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -110,6 +110,8 @@ let
     zathura # Lightweight and customizable PDF viewer
     texliveFull # Full TeX distribution for document compilation
     poppler-utils # Utilities for PDF manipulation
+    freetype
+    fontconfig
   ];
 
   # 2.13: System Monitoring & Information Tools
@@ -126,6 +128,7 @@ let
   # 2.14: Networking Tools
   pkgs2_14 = with pkgs; [
     git # Distributed version control system
+    inputs.codex-cli-nix.packages.${pkgs.system}.default # Codex CLI
     wirelesstools # Tools for managing wireless interfaces
     docker-compose # Define and run multi-container Docker applications
     wavemon # Network analysis tool (verify details online)
@@ -254,6 +257,7 @@ in
     dedicatedServer.openFirewall = true;
     localNetworkGameTransfers.openFirewall = true; # Open ports in the firewall for Steam Local Network Game Transfers
     # gamescopeSession.enable = true;
+    #
   };
   programs.gamescope.enable = true;
 

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -4,11 +4,6 @@ let
   # Stable packages from an alternate channel. For example, you might add kicad here.
   stablepkgs = with pkgs-stable; [
     # kicad
-    audacity # Audio editor for recording and editing
-    moc # Console audio player
-    protonvpn-gui # Graphical ProtonVPN client
-    gimp-with-plugins # Image editing software with additional plugins
-    usbutils
   ];
 
   # 2.0: To categorize
@@ -16,6 +11,11 @@ let
     nodejs
     jq
     icu
+    audacity # Audio editor for recording and editing
+    moc # Console audio player
+    protonvpn-gui # Graphical ProtonVPN client
+    gimp-with-plugins # Image editing software with additional plugins
+    usbutils
   ];
 
   # 2.1: General Productivity & Multimedia Tools
@@ -128,7 +128,7 @@ let
   # 2.14: Networking Tools
   pkgs2_14 = with pkgs; [
     git # Distributed version control system
-    inputs.codex-cli-nix.packages.${pkgs.system}.default # Codex CLI
+    inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.default # Codex CLI
     wirelesstools # Tools for managing wireless interfaces
     docker-compose # Define and run multi-container Docker applications
     wavemon # Network analysis tool (verify details online)
@@ -137,8 +137,8 @@ let
   # 2.15: Browsers & Internet Utilities
   pkgs2_15 = with pkgs; [
     # Firefox with custom native messaging hosts for pipewire audio capture.
-    #(firefox.override { nativeMessagingHosts = [ inputs.pipewire-screenaudio.packages.${pkgs.system}.default ]; })
-    inputs.zen-browser.packages.${pkgs.system}.default # zen-browser
+    #(firefox.override { nativeMessagingHosts = [ inputs.pipewire-screenaudio.packages.${pkgs.stdenv.hostPlatform.system}.default ]; })
+    inputs.zen-browser.packages.${pkgs.stdenv.hostPlatform.system}.default # zen-browser
     ungoogled-chromium
     w3m # Text-based web browser
   ];
@@ -203,9 +203,11 @@ let
 
   # 2.25: Screenshots & Wallpaper Management
   pkgs2_25 = with pkgs; [
-    # grimblast: screenshot utility for Hyprland (sourced from hyprland-contrib).
-    inputs.hyprland-contrib.packages.${pkgs.system}.grimblast
-    swappy # Alternative screenshot tool
+    hyprshot # Screenshot utility for Hyprland
+    hyprpicker # Color picker for Hyprland
+    grim # Grab images from a Wayland compositor
+    slurp # Select a region in a Wayland compositor
+    satty # Screenshot annotation tool
     swaybg # Wallpaper setter for Wayland compositors
     ksnip
   ];

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -7,6 +7,8 @@ let
     audacity # Audio editor for recording and editing
     moc # Console audio player
     protonvpn-gui # Graphical ProtonVPN client
+    gimp-with-plugins # Image editing software with additional plugins
+    usbutils
   ];
 
   # 2.0: To categorize
@@ -23,7 +25,6 @@ let
     winetricks # Helper to run Windows applications via Wine
     onlyoffice-desktopeditors # Office suite for document editing
     feh # Lightweight image viewer and wallpaper setter
-    gimp-with-plugins # Image editing software with additional plugins
     dosbox-staging # DOS emulator for legacy software
     libmpg123 # MP3 decoding library
     pipes # Fun terminal pipe animations
@@ -76,6 +77,7 @@ let
     libvterm # Terminal emulator library
     neofetch # System information tool for the terminal
     kitty # Modern, GPU-accelerated terminal emulator
+    usb-modeswitch
   ];
 
   # 2.8: Calculator

--- a/packages/desktop.nix
+++ b/packages/desktop.nix
@@ -10,7 +10,7 @@ let
 
   # 3.2: Video Editing
   pkgs3_2 = with pkgs; [
-    # davinci-resolve # Professional video editor
+    davinci-resolve # Professional video editor
   ];
 
   # 3.3: Virtualization

--- a/packages/desktop.nix
+++ b/packages/desktop.nix
@@ -10,7 +10,7 @@ let
 
   # 3.2: Video Editing
   pkgs3_2 = with pkgs; [
-    davinci-resolve # Professional video editor
+    # davinci-resolve # Professional video editor
   ];
 
   # 3.3: Virtualization

--- a/packages/rtl8852cu.nix
+++ b/packages/rtl8852cu.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "morrownr";
     repo = "rtl8852cu-20240510";
-    rev = "c01bd409ddce75822cd9127ac1a97ba4fd31a9d8";
-    hash = "sha256-yp5e2ijkqKji+dJ+XPMJJPhkjh5NYUiFEncQc4HdNEA=";
+    rev = "df11acdb628b1c781d34101a998ae2ed606190a0";
+    hash = "sha256-SXAPaDXY04RGs8DhUf9AKZV9qBLZITjLtW5LAYvlBOY=";
   };
 
   nativeBuildInputs = [ bc nukeReferences ] ++ kernel.moduleBuildDependencies;

--- a/packages/rtw89-firmware.nix
+++ b/packages/rtw89-firmware.nix
@@ -7,8 +7,8 @@ stdenv.mkDerivation rec {
   src = fetchFromGitHub {
     owner = "morrownr";
     repo = "rtw89";
-    rev = "7da080fc2fc75709364943c7ef2b39fa5abcef77";
-    hash = "sha256-psl39LMyXZh4Not6qWSdanze19GX0G52QbtLM7cO8JA=";
+    rev = "9049c42642c9db68f01efadf54f7cff07a46edc5";
+    hash = "sha256-sn15lMMawCm2FuARLcgbmPur00BJJCLYV4aGmn9HKNg=";
   };
 
   # Important : sinon stdenv voit un Makefile et lance make

--- a/scripts/check-hyprland-rules.sh
+++ b/scripts/check-hyprland-rules.sh
@@ -6,13 +6,18 @@ cd "$repo_root"
 
 fail=0
 
-if rg -n "windowrule\\s*=" .; then
-  echo "ERROR: legacy windowrule syntax found. Use windowrulev2 instead." >&2
+if rg -n "windowrulev2\\s*=" .; then
+  echo "ERROR: deprecated windowrulev2 syntax found. Use windowrule with match:* props." >&2
   fail=1
 fi
 
-if rg -n "type:\\s*initialTitle" .; then
-  echo "ERROR: legacy type:initialTitle matcher found. Use initialTitle instead." >&2
+if rg -n "windowrule\\s*=.*(class:|title:|initialTitle:|initialClass:)" .; then
+  echo "ERROR: legacy v2 matcher syntax found in windowrule. Use match:class/title/initial_title/initial_class." >&2
+  fail=1
+fi
+
+if rg -n "windowrule\\s*=.*stayfocused" .; then
+  echo "ERROR: deprecated stayfocused rule found. Use stay_focused." >&2
   fail=1
 fi
 

--- a/scripts/satty-shot.sh
+++ b/scripts/satty-shot.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hyprpicker -r -z >/dev/null 2>&1 &
+picker_pid=$!
+cleanup() {
+  kill "$picker_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+sleep 0.2
+geometry="$(slurp -d)" || exit 0
+kill "$picker_pid" 2>/dev/null || true
+grim -g "$geometry" -t ppm - | satty --filename - --fullscreen


### PR DESCRIPTION
## **PR Title**

`feat(nixos): migrate Hyprland rules to new syntax, add Codex CLI flake, update Realtek drivers & screenshot stack`

---

## **PR Description**

### Overview

This PR performs a structured modernization of the NixOS configuration and flake setup, including:

* Migration to the new Hyprland `windowrule` syntax
* Integration of `codex-cli-nix` as a flake input
* Update of Realtek drivers and firmware revisions
* Replacement of legacy screenshot tooling
* Nixpkgs and Home Manager updates
* Cleanup and reorganization of packages

---

## Changes

### 1. Hyprland configuration modernization

* Migrated deprecated `windowrulev2` syntax to the new `windowrule` format using `match:*` properties.
* Replaced deprecated `stayfocused` with `stay_focused`.
* Updated screenshot workflow:

  * Removed `grimblast` and `swappy`
  * Added `hyprshot`, `hyprpicker`, `grim`, `slurp`, and `satty`
  * Introduced `satty-shot.sh` helper script
* Added `layerrule` to prevent selection overlay animation artifacts in screenshots.
* Updated validation script to:

  * Detect deprecated `windowrulev2`
  * Detect legacy matcher syntax (`class:`, `title:`, etc.)
  * Detect deprecated `stayfocused`

This ensures forward compatibility with current Hyprland configuration standards.

---

### 2. Codex CLI integration

* Added `codex-cli-nix` as a flake input.
* Exposed the package via:

```nix
inputs.codex-cli-nix.packages.${pkgs.stdenv.hostPlatform.system}.default
```

* Installed Codex CLI in networking tools package group.

This allows fully declarative installation of Codex CLI.

---

### 3. Realtek / USB fixes

* Updated udev rule for TP-Link TXE70UH:

  * Corrected vendor/product IDs to `0bda:1a2b`
* Updated:

  * `rtl8852cu` driver revision + hash
  * `rtw89` firmware revision + hash
* Added `usb-modeswitch` and `usbutils` explicitly to system packages.

Improves reliability of Realtek USB Wi-Fi devices and aligns with current upstream revisions.

---

### 4. Flake updates

* Updated:

  * `nixpkgs`
  * `nixpkgs-stable`
  * `nixpkgs-unstable`
  * `home-manager`
  * `stylix`
  * `zen-browser`
* Introduced separate nixpkgs inputs to resolve dependency graph shifts.
* Removed `hyprland-contrib` (no longer needed after grimblast removal).

---

### 5. Package cleanup & reorganization

* Reorganized stable vs regular packages.
* Moved some multimedia tools into categorized groups.
* Added:

  * `gimp-with-plugins`
  * `freetype`
  * `fontconfig`
* Switched to `${pkgs.stdenv.hostPlatform.system}` for better cross-system correctness.

---

### 6. Neovim config fix

* Replaced deprecated `extraLuaConfig` with `initLua`.

Aligns with current Home Manager Neovim module expectations.

---

## Impact

* Configuration is now compatible with modern Hyprland rule syntax.
* Screenshot workflow is cleaner and Wayland-native.
* Realtek USB Wi-Fi reliability improved.
* Codex CLI is now fully declarative.
* Flake inputs are modernized and dependency graph clarified.

---

## Notes

* This PR removes deprecated syntax and enforces stricter validation.
* All changes build and evaluate correctly under current `nixpkgs-unstable`.
