### PR TITLE
rtw89: add usb_storage quirks modprobe config

### DIFF
--- a/drivers/rtw89.nix
+++ b/drivers/rtw89.nix
@@ -18,6 +18,15 @@ in
 
   environment.etc = {
     "modprobe.d/rtw89.conf".source = "${rtw89}/etc/modprobe.d/rtw89.conf";
+
+    # Recommended by morrownr/rtw89 (Q6) to prevent long boot times when the
+    # USB dongle is already inserted at boot.
+    "modprobe.d/usb_storage.conf".text = ''
+      # This tells usb_storage not to touch Realtek USB Wi-Fi dongles.
+      # Otherwise, computers may take a very long time to boot or
+      # usb_modeswitch may fail to switch them to Wi-Fi mode.
+      options usb_storage quirks=0bda:1a2b:i,0bda:a192:i
+    '';
   };
 
   assertions = [


### PR DESCRIPTION
### Motivation
- Integrate the `morrownr/rtw89` recommendation to prevent very long boot times or `usb_modeswitch` failures when a Realtek USB Wi‑Fi dongle is already inserted by adding a `usb_storage` quirks file.

### Description
- Add `/etc/modprobe.d/usb_storage.conf` via `environment.etc` in `drivers/rtw89.nix` that sets `options usb_storage quirks=0bda:1a2b:i,0bda:a192:i`, so the driver package automatically installs the recommended quirk when the `rtw89` module is enabled (the laptop host already imports this module).

### Testing
- Ran `nix --extra-experimental-features 'nix-command flakes' flake show` (OK) and `nix --extra-experimental-features 'nix-command flakes' flake check --no-build` (failed with an unrelated Nix store validity error), and noted that `nix flake show` without experimental flags errors in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad476e3c70833199ebf1dcc6e049aa)