### PR TITLE
Add MkDocs bilingual documentation, many docs pages, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,39 @@
-# NixOS Configuration
+# NixOS configuration (flake)
 
-The repository is organized into key directories: `hosts/` defines the `desktop` and `laptop` machines, while `packages/` and `overlays/` provide custom packages and overlay tweaks. Reference hosts by name in flake commands, for example:
+Configuration NixOS personnelle pour deux machines (`desktop` et `laptop`) avec Home Manager, Stylix et Hyprland.
+
+## Documentation
+
+La documentation est maintenant structurée avec **MkDocs Material** et disponible en **français** et en **anglais**.
+
+- Français: [`docs/index.md`](docs/index.md)
+- English: [`docs/en/index.md`](docs/en/index.md)
+- Ancien document monolithique: [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) (conservé temporairement le temps de la migration)
+
+### Lancer la doc en local
 
 ```sh
+mkdocs serve
+```
+
+### Construire la doc statique
+
+```sh
+mkdocs build
+```
+
+## Commandes NixOS usuelles
+
+```sh
+# Prévisualiser les sorties de la flake
+nix flake show
+
+# Vérifier la flake sans build complet
+nix flake check --no-build
+
+# Appliquer la configuration desktop
 sudo nixos-rebuild switch --flake .#desktop
-nix flake show .#nixosConfigurations.laptop
+
+# Appliquer la configuration laptop
+sudo nixos-rebuild switch --flake .#laptop
 ```
-
-This repository contains the NixOS configuration for both a desktop and a laptop setup. For a full description of the available modules and options see [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
-
-## Getting Started
-
-1. Clone the repository:
-   ```sh
-   git clone https://github.com/LAlto96/nixos.git
-   cd nixos
-   ```
-
-2. Apply the configuration for a host:
-   ```sh
-   sudo nixos-rebuild switch --flake .#desktop
-   ```
-   Use `.#laptop` in place of `.#desktop` to build the laptop configuration.
-
-Home-manager modules for each user are included automatically via the flake.
-
-### Tailscale VPN
-
-After switching to the configuration, run the following command on each machine
-to join your Tailnet:
-
-```sh
-sudo tailscale up --auth-key=<YOUR_KEY>
-```
-
-Replace `<YOUR_KEY>` with an auth key created at
-<https://login.tailscale.com/admin/machines/new-linux>.
-

--- a/docs/architecture/flake.md
+++ b/docs/architecture/flake.md
@@ -1,0 +1,29 @@
+# Flake
+
+## Inputs principaux
+
+La flake déclare notamment:
+
+- `nixpkgs` (canal principal)
+- `nixpkgs-stable`
+- `nixpkgs-unstable`
+- `home-manager`
+- `stylix`
+- `zen-browser`
+- `pipewire-screenaudio`
+- `codex-cli-nix`
+
+Voir aussi la page [Inputs](../reference/inputs.md).
+
+## Outputs utilisés
+
+- `nixosConfigurations.desktop`
+- `nixosConfigurations.laptop`
+- `overlays.imagemagick-compat`
+- `checks.x86_64-linux.hyprland-rules`
+
+## Spécificités
+
+- `desktop` reçoit `pkgs-stable` **et** `pkgs-unstable` dans `specialArgs`.
+- `laptop` reçoit `pkgs-stable` dans `specialArgs`.
+- Les deux hosts utilisent `commonModules` puis ajoutent leur module host.

--- a/docs/architecture/module-graph.md
+++ b/docs/architecture/module-graph.md
@@ -1,0 +1,32 @@
+# Graphe des modules
+
+```mermaid
+flowchart LR
+  subgraph Common
+    CM[common-modules.nix] --> CFG[configuration.nix]
+    CM --> HMN[home-manager.nixosModules.home-manager]
+    CM --> STYLIX[stylix.nixosModules.stylix]
+  end
+
+  subgraph Desktop
+    HD[hosts/desktop/default.nix] --> HWD[hardware-configuration-desktop.nix]
+    HD --> NG[nvidiagpu.nix]
+    HD --> PD[packages/desktop.nix]
+    HD --> RTW89D[drivers/rtw89.nix]
+    HD --> HOMED[home-desktop.nix]
+  end
+
+  subgraph Laptop
+    HL[hosts/laptop/default.nix] --> HWL[hardware-configuration-laptop.nix]
+    HL --> AG[amdgpu.nix]
+    HL --> PL[packages/laptop.nix]
+    HL --> TLP[tlp.nix]
+    HL --> RTW89L[drivers/rtw89.nix]
+    HL --> HOMEL[home-laptop.nix]
+  end
+```
+
+## À retenir
+
+- Les modules GPU sont séparés (`amdgpu.nix`, `nvidiagpu.nix`).
+- Les paquets communs sont dans `packages/common.nix`; les extras host sont séparés.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,31 @@
+# Vue d'ensemble
+
+La flake expose deux configurations NixOS:
+
+- `desktop`
+- `laptop`
+
+Les deux hosts partagent un socle commun (`common-modules.nix` + `configuration.nix`) puis ajoutent leurs modules spécifiques (GPU, paquets, services).
+
+```mermaid
+flowchart TD
+  A[flake.nix] --> B[common-modules.nix]
+  B --> C[configuration.nix]
+  B --> D[stylix.nixosModules.stylix]
+  B --> E[home-manager.nixosModules.home-manager]
+
+  A --> F[hosts/desktop/default.nix]
+  A --> G[hosts/laptop/default.nix]
+
+  F --> H[home-desktop.nix]
+  G --> I[home-laptop.nix]
+
+  H --> J[wm-desktop/wm.nix]
+  I --> K[wm-laptop/wm.nix]
+```
+
+## Principes
+
+1. **Base commune**: boot, réseau, sécurité, audio, services partagés.
+2. **Spécificité par machine**: GPU, virtualisation, firewall, tuning.
+3. **Session utilisateur**: Home Manager + configuration WM.

--- a/docs/architecture/repository-layout.md
+++ b/docs/architecture/repository-layout.md
@@ -1,0 +1,18 @@
+# Arborescence du dépôt
+
+## Répertoires clés
+
+| Chemin | Rôle |
+|---|---|
+| `flake.nix` | Entrée principale et composition des outputs |
+| `common-modules.nix` | Modules partagés par tous les hosts |
+| `configuration.nix` | Configuration système commune |
+| `hosts/` | Configuration spécifique par machine |
+| `home-*.nix` | Entrées Home Manager par host |
+| `hm/` | Modules Home Manager partagés |
+| `wm-desktop/`, `wm-laptop/` | Config Hyprland/rofi/kitty par host |
+| `packages/` | Paquets communs et paquets spécifiques |
+| `overlays/` | Overlays Nixpkgs |
+| `drivers/` | Modules de drivers noyau/firmware |
+| `scripts/` | Scripts utilitaires/checks |
+| `docs/` | Documentation MkDocs |

--- a/docs/development/checks.md
+++ b/docs/development/checks.md
@@ -1,0 +1,13 @@
+# Checks
+
+## Checks sûrs (sans build complet)
+
+```sh
+nix flake show
+nix flake check --no-build
+bash scripts/check-hyprland-rules.sh
+```
+
+## Check défini dans la flake
+
+La flake expose `checks.x86_64-linux.hyprland-rules` qui exécute `scripts/check-hyprland-rules.sh`.

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -1,0 +1,15 @@
+# CI
+
+## État actuel
+
+Aucune pipeline CI versionnée dans `.github/workflows/` dans cette repo.
+
+## Recommandation minimale
+
+- lancer `nix flake check --no-build`
+- lancer `bash scripts/check-hyprland-rules.sh`
+- (optionnel) `nix flake show`
+
+## À compléter
+
+Ajouter une CI GitHub Actions pour automatiser ces commandes à chaque PR.

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -1,0 +1,14 @@
+# Conventions
+
+## Nix
+
+- Éviter les refactors de masse sans besoin fonctionnel.
+- Ajouter les nouveaux modules via imports explicites.
+- Garder la séparation `commun` / `host`.
+
+## Documentation
+
+- Langue: français.
+- Commandes shell prêtes à copier.
+- Préférer des pages courtes et ciblées.
+- Marquer les zones incertaines avec **À compléter**.

--- a/docs/development/documentation-workflow.md
+++ b/docs/development/documentation-workflow.md
@@ -1,0 +1,21 @@
+# Workflow documentation
+
+## Ajouter/modifier une page
+
+1. Modifier le fichier Markdown ciblé sous `docs/`.
+2. Si nécessaire, mettre à jour `mkdocs.yml` (navigation).
+3. Prévisualiser localement.
+
+```sh
+mkdocs serve
+```
+
+## Build local
+
+```sh
+mkdocs build
+```
+
+## Migration de `docs/CONFIGURATION.md`
+
+Le fichier historique est conservé temporairement pour référence. Toute nouvelle documentation doit être ajoutée dans les pages structurées de `docs/`.

--- a/docs/en/architecture/flake.md
+++ b/docs/en/architecture/flake.md
@@ -1,0 +1,19 @@
+# Flake
+
+## Main inputs
+
+- `nixpkgs`
+- `nixpkgs-stable`
+- `nixpkgs-unstable`
+- `home-manager`
+- `stylix`
+- `zen-browser`
+- `pipewire-screenaudio`
+- `codex-cli-nix`
+
+## Exposed outputs
+
+- `nixosConfigurations.desktop`
+- `nixosConfigurations.laptop`
+- `overlays.imagemagick-compat`
+- `checks.x86_64-linux.hyprland-rules`

--- a/docs/en/architecture/module-graph.md
+++ b/docs/en/architecture/module-graph.md
@@ -1,0 +1,18 @@
+# Module graph
+
+```mermaid
+flowchart LR
+  CM[common-modules.nix] --> CFG[configuration.nix]
+  CM --> HMN[home-manager module]
+  CM --> STYLIX[stylix module]
+
+  HD[hosts/desktop/default.nix] --> HWD[hardware-configuration-desktop.nix]
+  HD --> NG[nvidiagpu.nix]
+  HD --> PD[packages/desktop.nix]
+  HD --> HOMED[home-desktop.nix]
+
+  HL[hosts/laptop/default.nix] --> HWL[hardware-configuration-laptop.nix]
+  HL --> AG[amdgpu.nix]
+  HL --> PL[packages/laptop.nix]
+  HL --> HOMEL[home-laptop.nix]
+```

--- a/docs/en/architecture/overview.md
+++ b/docs/en/architecture/overview.md
@@ -1,0 +1,25 @@
+# Overview
+
+The flake exposes two NixOS configurations:
+
+- `desktop`
+- `laptop`
+
+Both hosts share a common base (`common-modules.nix` + `configuration.nix`) and then add host-specific modules (GPU, packages, services).
+
+```mermaid
+flowchart TD
+  A[flake.nix] --> B[common-modules.nix]
+  B --> C[configuration.nix]
+  B --> D[stylix.nixosModules.stylix]
+  B --> E[home-manager.nixosModules.home-manager]
+
+  A --> F[hosts/desktop/default.nix]
+  A --> G[hosts/laptop/default.nix]
+
+  F --> H[home-desktop.nix]
+  G --> I[home-laptop.nix]
+
+  H --> J[wm-desktop/wm.nix]
+  I --> K[wm-laptop/wm.nix]
+```

--- a/docs/en/architecture/repository-layout.md
+++ b/docs/en/architecture/repository-layout.md
@@ -1,0 +1,14 @@
+# Repository layout
+
+| Path | Role |
+|---|---|
+| `flake.nix` | Main entry point |
+| `common-modules.nix` | Shared modules for all hosts |
+| `configuration.nix` | Shared system configuration |
+| `hosts/` | Host-specific modules |
+| `home-*.nix` | Home Manager entry points |
+| `hm/` | Shared Home Manager modules |
+| `packages/` | Shared + host package sets |
+| `overlays/` | Nixpkgs overlays |
+| `drivers/` | Driver modules |
+| `scripts/` | Utility/check scripts |

--- a/docs/en/development/checks.md
+++ b/docs/en/development/checks.md
@@ -1,0 +1,7 @@
+# Checks
+
+```sh
+nix flake show
+nix flake check --no-build
+bash scripts/check-hyprland-rules.sh
+```

--- a/docs/en/development/ci.md
+++ b/docs/en/development/ci.md
@@ -1,0 +1,10 @@
+# CI
+
+No CI workflow is currently versioned in `.github/workflows/`.
+
+## To be completed
+
+Add a GitHub Actions workflow for at least:
+
+- `nix flake check --no-build`
+- `bash scripts/check-hyprland-rules.sh`

--- a/docs/en/development/conventions.md
+++ b/docs/en/development/conventions.md
@@ -1,0 +1,5 @@
+# Conventions
+
+- Keep docs concise and actionable.
+- Keep commands copy-paste friendly.
+- Avoid documenting behavior not present in the repo.

--- a/docs/en/development/documentation-workflow.md
+++ b/docs/en/development/documentation-workflow.md
@@ -1,0 +1,9 @@
+# Documentation workflow
+
+1. Edit the relevant `docs/*.md` file.
+2. Update `mkdocs.yml` navigation if needed.
+3. Preview locally:
+
+```sh
+mkdocs serve
+```

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -1,0 +1,45 @@
+# Getting started
+
+## Prerequisites
+
+- Nix with `nix-command` and `flakes` enabled.
+- A host declared in `flake.nix` (`desktop` or `laptop`).
+
+## Clone the repository
+
+```sh
+git clone https://github.com/LAlto96/nixos.git
+cd nixos
+```
+
+## Explore flake outputs
+
+```sh
+nix flake show
+```
+
+## Quick validation
+
+```sh
+nix flake check --no-build
+```
+
+## Apply a host config
+
+```sh
+sudo nixos-rebuild switch --flake .#desktop
+```
+
+For laptop:
+
+```sh
+sudo nixos-rebuild switch --flake .#laptop
+```
+
+## After first switch
+
+If you use Tailscale:
+
+```sh
+sudo tailscale up --auth-key=<YOUR_KEY>
+```

--- a/docs/en/hosts/adding-a-host.md
+++ b/docs/en/hosts/adding-a-host.md
@@ -1,0 +1,12 @@
+# Adding a host
+
+1. Create `hosts/<new-host>/default.nix` and import required hardware/GPU/package modules.
+2. Declare the host under `nixosConfigurations` in `flake.nix`.
+3. Wire Home Manager user (`home-manager.users.<user>`) and trusted user.
+4. Validate:
+
+```sh
+nix flake show
+nix flake check --no-build
+sudo nixos-rebuild dry-activate --flake .#<new-host>
+```

--- a/docs/en/hosts/desktop.md
+++ b/docs/en/hosts/desktop.md
@@ -1,0 +1,16 @@
+# Host `desktop`
+
+## Imports
+
+- `hardware-configuration-desktop.nix`
+- `nvidiagpu.nix`
+- `packages/desktop.nix`
+- `drivers/rtw89.nix`
+
+## Key specifics
+
+- SSH enabled on port `2268`
+- Docker + libvirtd + virt-manager enabled
+- `vm.swappiness = 60`
+- CPU governor `performance`
+- SDDM + Plasma 6 + default session `hyprland`

--- a/docs/en/hosts/laptop.md
+++ b/docs/en/hosts/laptop.md
@@ -1,0 +1,16 @@
+# Host `laptop`
+
+## Imports
+
+- `hardware-configuration-laptop.nix`
+- `amdgpu.nix`
+- `packages/laptop.nix`
+- `tlp.nix`
+- `drivers/rtw89.nix`
+
+## Key specifics
+
+- Bluetooth + `blueman` enabled
+- 16 GiB swapfile at `/var/lib/swapfile`
+- `vm.swappiness = 20`
+- SDDM + Plasma 6 + default session `hyprland`

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,23 @@
+# NixOS configuration documentation
+
+Welcome to the documentation for the `LAlto96/nixos` repository.
+
+## What you will find
+
+- **Architecture**: flake structure, modules, repository layout.
+- **Hosts**: differences between `desktop` and `laptop`, and how to add a new host.
+- **Modules**: system, Home Manager, packages, overlays, GPU, Hyprland, Stylix.
+- **Operations**: rebuild, flake updates, rollback, troubleshooting, Tailscale.
+- **Development**: checks, conventions, documentation maintenance.
+- **Reference**: shell aliases, open ports, package groups, flake inputs.
+
+## Scope
+
+This documentation only covers behavior that exists in this repository.
+
+> Incomplete areas are explicitly marked **To be completed**.
+
+
+## Languages
+
+- Version française : [Documentation française](../index.md)

--- a/docs/en/modules/common-modules.md
+++ b/docs/en/modules/common-modules.md
@@ -1,0 +1,8 @@
+# `common-modules.nix`
+
+Composes shared modules:
+
+- `stylix.nixosModules.stylix`
+- `configuration.nix`
+- `home-manager.nixosModules.home-manager`
+- shared overlay wiring (`imagemagick-compat`)

--- a/docs/en/modules/gpu.md
+++ b/docs/en/modules/gpu.md
@@ -1,0 +1,4 @@
+# GPU
+
+- `amdgpu.nix`: AMD driver stack + Vulkan/ROCm components.
+- `nvidiagpu.nix`: NVIDIA stack with open kernel module and beta package selection.

--- a/docs/en/modules/home-manager.md
+++ b/docs/en/modules/home-manager.md
@@ -1,0 +1,8 @@
+# Home Manager
+
+Entry points:
+
+- `home-desktop.nix`
+- `home-laptop.nix`
+
+Shared imports include `hm/zsh.nix`, `hm/neovim.nix`, `hm/vscode.nix` and host WM module.

--- a/docs/en/modules/hyprland.md
+++ b/docs/en/modules/hyprland.md
@@ -1,0 +1,12 @@
+# Hyprland
+
+Configuration is split into:
+
+- shared base: `hyprland.base.conf`
+- host overrides: `wm-desktop/hyprland.conf` / `wm-laptop/hyprland.conf`
+
+Validation helper:
+
+```sh
+bash scripts/check-hyprland-rules.sh
+```

--- a/docs/en/modules/overlays.md
+++ b/docs/en/modules/overlays.md
@@ -1,0 +1,5 @@
+# Overlays
+
+- `overlays/imagemagick-compat.nix`: active overlay used by the flake.
+- `overlays/resolve-no-multiarch.nix`: present but not currently wired.
+- `overlays/rtl8852cu.nix`: present but not currently wired.

--- a/docs/en/modules/packages.md
+++ b/docs/en/modules/packages.md
@@ -1,0 +1,5 @@
+# Package modules
+
+- `packages/common.nix`: shared package groups (`pkgs2_*`) + Steam/Gamescope.
+- `packages/desktop.nix`: desktop-focused extras (DAW, video, virtualization, benchmarks).
+- `packages/laptop.nix`: laptop additions (`powertop`).

--- a/docs/en/modules/services.md
+++ b/docs/en/modules/services.md
@@ -1,0 +1,5 @@
+# Services
+
+Shared enabled services include Tailscale, Flatpak, Udisks2, Emacs, D-Bus, and Hypridle.
+
+Host-specific services differ between desktop (SSH, Docker, libvirtd) and laptop (Bluetooth/Blueman, TLP).

--- a/docs/en/modules/stylix.md
+++ b/docs/en/modules/stylix.md
@@ -1,0 +1,7 @@
+# Stylix
+
+Stylix is enabled from `common-modules.nix` and configured in `configuration.nix`:
+
+- wallpaper from `hm/wallpaper/wall3.png`
+- Catppuccin Latte base16 scheme
+- cursor + font customization

--- a/docs/en/modules/system.md
+++ b/docs/en/modules/system.md
@@ -1,0 +1,9 @@
+# System module (`configuration.nix`)
+
+Covers boot/kernel, networking, locale, users, Nix settings, Wayland programs, audio, Stylix, and shared services.
+
+Notable points:
+
+- `services.tailscale.enable = true`
+- user service `hyprsunset`
+- `system.stateVersion = "23.05"`

--- a/docs/en/operations/rebuild.md
+++ b/docs/en/operations/rebuild.md
@@ -1,0 +1,8 @@
+# Rebuild
+
+| Mode | Command |
+|---|---|
+| Preview | `sudo nixos-rebuild dry-activate --flake .#desktop` |
+| Temporary | `sudo nixos-rebuild test --flake .#desktop` |
+| Permanent | `sudo nixos-rebuild switch --flake .#desktop` |
+| Next boot | `sudo nixos-rebuild boot --flake .#desktop` |

--- a/docs/en/operations/rollback.md
+++ b/docs/en/operations/rollback.md
@@ -1,0 +1,6 @@
+# Rollback
+
+```sh
+sudo nixos-rebuild switch --rollback
+nixos-rebuild list-generations
+```

--- a/docs/en/operations/tailscale.md
+++ b/docs/en/operations/tailscale.md
@@ -1,0 +1,9 @@
+# Tailscale
+
+Tailscale service is enabled in shared config.
+
+```sh
+sudo tailscale up --auth-key=<YOUR_KEY>
+systemctl status tailscaled
+sudo tailscale status
+```

--- a/docs/en/operations/troubleshooting.md
+++ b/docs/en/operations/troubleshooting.md
@@ -1,0 +1,10 @@
+# Troubleshooting
+
+Useful commands:
+
+```sh
+nix flake show
+nix flake check --no-build
+git status
+bash scripts/check-hyprland-rules.sh
+```

--- a/docs/en/operations/update-flake.md
+++ b/docs/en/operations/update-flake.md
@@ -1,0 +1,7 @@
+# Update flake
+
+```sh
+nix flake update
+nix flake lock --update-input nixpkgs
+nix flake check --no-build
+```

--- a/docs/en/reference/aliases.md
+++ b/docs/en/reference/aliases.md
@@ -1,0 +1,3 @@
+# Aliases
+
+This repository defines shared aliases in `hm/zsh.nix` and host-specific aliases in `home-desktop.nix` / `home-laptop.nix`.

--- a/docs/en/reference/inputs.md
+++ b/docs/en/reference/inputs.md
@@ -1,0 +1,12 @@
+# Flake inputs
+
+Declared in `flake.nix`:
+
+- `nixpkgs`
+- `nixpkgs-stable`
+- `nixpkgs-unstable`
+- `home-manager`
+- `stylix`
+- `pipewire-screenaudio`
+- `codex-cli-nix`
+- `zen-browser`

--- a/docs/en/reference/package-groups.md
+++ b/docs/en/reference/package-groups.md
@@ -1,0 +1,8 @@
+# Package groups
+
+Shared package groups are maintained in `packages/common.nix` under `pkgs2_*` lists.
+
+Host-specific package additions:
+
+- `packages/desktop.nix` (`pkgs3_*` lists)
+- `packages/laptop.nix`

--- a/docs/en/reference/ports.md
+++ b/docs/en/reference/ports.md
@@ -1,0 +1,5 @@
+# Ports
+
+Desktop ports come from `hosts/desktop/ports.nix` and are applied to both TCP and UDP.
+
+Laptop exposes: `80, 91, 443, 444, 8501, 9100` (TCP/UDP).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,45 @@
+# Getting started
+
+## Prérequis
+
+- Nix avec les fonctionnalités `nix-command` et `flakes`.
+- Un host déclaré dans `flake.nix` (`desktop` ou `laptop`).
+
+## Cloner la repository
+
+```sh
+git clone https://github.com/LAlto96/nixos.git
+cd nixos
+```
+
+## Explorer les sorties
+
+```sh
+nix flake show
+```
+
+## Vérification rapide
+
+```sh
+nix flake check --no-build
+```
+
+## Appliquer un host
+
+```sh
+sudo nixos-rebuild switch --flake .#desktop
+```
+
+Pour le laptop:
+
+```sh
+sudo nixos-rebuild switch --flake .#laptop
+```
+
+## Après premier switch
+
+Si vous utilisez Tailscale:
+
+```sh
+sudo tailscale up --auth-key=<VOTRE_CLE>
+```

--- a/docs/hosts/adding-a-host.md
+++ b/docs/hosts/adding-a-host.md
@@ -1,0 +1,45 @@
+# Ajouter un host
+
+## 1) Créer le module host
+
+Créer `hosts/<nouveau-host>/default.nix` puis importer:
+
+- un fichier hardware (`hardware-configuration-*.nix`),
+- les modules GPU adaptés,
+- les paquets spécifiques,
+- éventuels modules services/drivers.
+
+## 2) Déclarer le host dans `flake.nix`
+
+```nix
+nixosConfigurations.<nouveau-host> = nixpkgs.lib.nixosSystem {
+  specialArgs = {
+    inherit inputs;
+    pkgs-stable = import nixpkgs-stable {
+      inherit system;
+      config.allowUnfree = true;
+    };
+  };
+  modules = commonModules ++ [
+    { nixpkgs.hostPlatform = system; }
+    ./hosts/<nouveau-host>
+  ];
+};
+```
+
+## 3) Ajouter le Home Manager utilisateur
+
+Dans le module host:
+
+```nix
+home-manager.users.<user> = import ../../home-<host>.nix;
+nix.settings.trusted-users = [ "<user>" ];
+```
+
+## 4) Vérifier
+
+```sh
+nix flake show
+nix flake check --no-build
+sudo nixos-rebuild dry-activate --flake .#<nouveau-host>
+```

--- a/docs/hosts/desktop.md
+++ b/docs/hosts/desktop.md
@@ -1,0 +1,21 @@
+# Host `desktop`
+
+## Imports
+
+- `hardware-configuration-desktop.nix`
+- `nvidiagpu.nix`
+- `packages/desktop.nix`
+- `drivers/rtw89.nix`
+
+## Particularités
+
+- SSH activé sur le port `2268`.
+- Docker + libvirtd + virt-manager activés.
+- `vm.swappiness = 60`.
+- Gouverneur CPU `performance`.
+- SDDM + Plasma 6 + session par défaut `hyprland`.
+- Home Manager utilisateur: `desktop`.
+
+## Firewall
+
+Les ports sont centralisés dans `hosts/desktop/ports.nix` et appliqués en TCP/UDP.

--- a/docs/hosts/laptop.md
+++ b/docs/hosts/laptop.md
@@ -1,0 +1,18 @@
+# Host `laptop`
+
+## Imports
+
+- `hardware-configuration-laptop.nix`
+- `amdgpu.nix`
+- `packages/laptop.nix`
+- `tlp.nix`
+- `drivers/rtw89.nix`
+
+## Particularités
+
+- Bluetooth activé (`blueman` activé).
+- Swapfile de 16 GiB (`/var/lib/swapfile`).
+- `vm.swappiness = 20`.
+- SDDM + Plasma 6 + session par défaut `hyprland`.
+- Home Manager utilisateur: `laptop`.
+- Alias énergie: `ac`, `bat`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+# Documentation de la configuration NixOS
+
+Bienvenue dans la documentation de la repo `LAlto96/nixos`.
+
+## Ce que vous trouverez ici
+
+- **Architecture** : structure flake, modules, arborescence.
+- **Hosts** : différences entre `desktop` et `laptop`, ajout d'un nouveau host.
+- **Modules** : système, Home Manager, paquets, overlays, GPU, Hyprland, Stylix.
+- **Opérations** : rebuild, update flake, rollback, dépannage, Tailscale.
+- **Développement** : checks, conventions, maintenance de la documentation.
+- **Référence** : aliases shell, ports ouverts, groupes de paquets, inputs flake.
+
+## Portée
+
+Cette documentation décrit uniquement les éléments présents dans la repo.
+
+> Si une section est incomplète, elle est marquée **À compléter**.
+
+
+## Langues
+
+- Version anglaise: [English documentation](en/index.md)

--- a/docs/modules/common-modules.md
+++ b/docs/modules/common-modules.md
@@ -1,0 +1,15 @@
+# `common-modules.nix`
+
+Ce fichier assemble les briques communes:
+
+- `stylix.nixosModules.stylix`
+- `./configuration.nix`
+- `home-manager.nixosModules.home-manager`
+- overlay `imagemagick-compat` côté système et Home Manager
+
+## Choix Home Manager
+
+- `home-manager.useGlobalPkgs = false`
+- `home-manager.useUserPackages = true`
+
+Cela garde une séparation nette entre paquets système et paquets utilisateurs.

--- a/docs/modules/gpu.md
+++ b/docs/modules/gpu.md
@@ -1,0 +1,19 @@
+# GPU
+
+## `amdgpu.nix`
+
+- Charge `amdgpu` en initrd.
+- Définit `services.xserver.videoDrivers = [ "amdgpu" ]`.
+- Active la stack graphics 32 bits.
+- Ajoute des composants Vulkan/ROCm.
+
+## `nvidiagpu.nix`
+
+- Active `cudaSupport`.
+- Définit `services.xserver.videoDrivers = [ "nvidia" ]`.
+- `hardware.nvidia.open = true`.
+- Pilote choisi: `config.boot.kernelPackages.nvidiaPackages.beta`.
+
+## Remarque
+
+Le host `laptop` importe `amdgpu.nix`, le host `desktop` importe `nvidiagpu.nix`.

--- a/docs/modules/home-manager.md
+++ b/docs/modules/home-manager.md
@@ -1,0 +1,31 @@
+# Home Manager
+
+## Entrées par host
+
+- `home-desktop.nix`
+- `home-laptop.nix`
+
+## Modules partagés importés
+
+- `hm/vscode.nix`
+- `hm/zsh.nix`
+- `hm/neovim.nix`
+- un module WM (`wm-desktop/wm.nix` ou `wm-laptop/wm.nix`)
+
+## Fichiers déployés
+
+Les deux profils déploient notamment:
+
+- configs Doom Emacs
+- configs btop
+- configs YouTube Music
+- `hypridle.conf` et `hyprlock`
+- fichiers hyprpanel
+
+## Différences principales
+
+| Sujet | desktop | laptop |
+|---|---|---|
+| Package utilisateur spécifique | - | `moonlight-qt` |
+| Alias zsh host | `valheim` | `ac`, `bat` |
+| Signature git | non forcée | `signing.format = openpgp` |

--- a/docs/modules/hyprland.md
+++ b/docs/modules/hyprland.md
@@ -1,0 +1,27 @@
+# Hyprland
+
+## Organisation
+
+- Base partagée: `hyprland.base.conf`
+- Surcharge host: `wm-desktop/hyprland.conf` ou `wm-laptop/hyprland.conf`
+- Liaison Nix/Home Manager: `wm-desktop/wm.nix` et `wm-laptop/wm.nix`
+
+Les modules WM concatènent la base et le fichier host via `wayland.windowManager.hyprland.extraConfig`.
+
+## Outils liés
+
+- `hyprpanel` (package système + fichiers JSON/SCSS côté home)
+- `hyprlock` + `hypridle`
+- script de check des règles: `scripts/check-hyprland-rules.sh`
+
+## Validation des règles
+
+```sh
+bash scripts/check-hyprland-rules.sh
+```
+
+Ce script échoue si:
+
+- `windowrulev2` est utilisé,
+- l'ancienne syntaxe de matcher est utilisée,
+- `stayfocused` est utilisé au lieu de `stay_focused`.

--- a/docs/modules/overlays.md
+++ b/docs/modules/overlays.md
@@ -1,0 +1,13 @@
+# Overlays
+
+## `overlays/imagemagick-compat.nix`
+
+Overlay appliqué globalement pour pinner `nixos-icons` et `imagemagick` sur une révision connue, afin d'éviter des crashs liés à Stylix/KDE.
+
+## `overlays/resolve-no-multiarch.nix`
+
+Présent dans la repo mais non branché dans la flake actuelle. Sert à désactiver le multi-arch dans l'environnement FHS de `davinci-resolve`.
+
+## `overlays/rtl8852cu.nix`
+
+Présent dans la repo mais non branché dans la flake actuelle. Expose `rtl8852cu` pour plusieurs familles de kernel packages.

--- a/docs/modules/packages.md
+++ b/docs/modules/packages.md
@@ -1,0 +1,21 @@
+# Modules paquets
+
+## `packages/common.nix`
+
+- Active Java, Steam et Gamescope.
+- Construit `environment.systemPackages` à partir de groupes `pkgs2_*`.
+- Ajoute `stablepkgs` depuis `pkgs-stable`.
+
+## `packages/desktop.nix`
+
+Ajoute des paquets orientés desktop:
+
+- audio/prod (`reaper`, `yabridge`)
+- vidéo (`davinci-resolve`)
+- virtualisation (`quickemu`)
+- bench/OC (`nvidia_oc`, `phoronix-test-suite`)
+- outils gaming depuis stable (`sgdboop`, `alvr`)
+
+## `packages/laptop.nix`
+
+Ajoute `powertop`.

--- a/docs/modules/services.md
+++ b/docs/modules/services.md
@@ -1,0 +1,26 @@
+# Services
+
+## Services système (socle commun)
+
+| Service | État |
+|---|---|
+| `services.tailscale` | activé |
+| `services.flatpak` | activé |
+| `services.udisks2` | activé |
+| `services.emacs` | activé |
+| `services.dbus` | activé |
+| `services.hypridle` | activé |
+
+## Services par host
+
+### Desktop
+
+- `services.openssh.enable = true`
+- `services.openssh.ports = [ 2268 ]`
+- `virtualisation.docker.enable = true`
+- `virtualisation.libvirtd.enable = true`
+
+### Laptop
+
+- `services.blueman.enable = true`
+- `services.tlp.enable = true` (via `tlp.nix`)

--- a/docs/modules/stylix.md
+++ b/docs/modules/stylix.md
@@ -1,0 +1,16 @@
+# Stylix
+
+Stylix est injecté depuis `common-modules.nix` et configuré dans `configuration.nix`.
+
+## Configuration active
+
+- `stylix.enable = true`
+- Image: `hm/wallpaper/wall3.png`
+- Schéma base16: `catppuccin-latte`
+- Curseur: `catppuccin-latte-sapphire-cursors` (taille 32)
+- Police principale: `JetBrainsMono NF`
+- `stylix.homeManagerIntegration.followSystem = true`
+
+## Cible explicitement désactivée
+
+- `stylix.targets.vscode.enable = false` dans `home-desktop.nix`.

--- a/docs/modules/system.md
+++ b/docs/modules/system.md
@@ -1,0 +1,18 @@
+# Configuration système (`configuration.nix`)
+
+## Domaines couverts
+
+- Boot/kernel (`systemd-boot`, `linuxPackages_6_18`, `v4l2loopback`)
+- Réseau (`NetworkManager`, DNS Cloudflare, IPv6 désactivé)
+- Locale/console (locale EN, clavier FR)
+- Utilisateurs (`desktop`, `laptop`)
+- Nix (flakes, registry, paquets non libres)
+- Programmes (Hyprland, hyprlock, hypridle, yazi, corectrl)
+- Audio (`pipewire`, PulseAudio désactivé)
+- Stylix (thème, curseur, polices)
+
+## Points notables
+
+- Service Tailscale activé globalement.
+- Service user `hyprsunset` activé sur session graphique.
+- `system.stateVersion = "23.05"`.

--- a/docs/operations/rebuild.md
+++ b/docs/operations/rebuild.md
@@ -1,0 +1,12 @@
+# Rebuild
+
+## Modes utiles
+
+| Mode | Commande | Effet |
+|---|---|---|
+| Aperçu | `sudo nixos-rebuild dry-activate --flake .#desktop` | simulation |
+| Temporaire | `sudo nixos-rebuild test --flake .#desktop` | actif jusqu'au reboot |
+| Permanent | `sudo nixos-rebuild switch --flake .#desktop` | actif immédiatement |
+| Boot suivant | `sudo nixos-rebuild boot --flake .#desktop` | appliqué au prochain démarrage |
+
+Remplacez `desktop` par `laptop` selon le cas.

--- a/docs/operations/rollback.md
+++ b/docs/operations/rollback.md
@@ -1,0 +1,17 @@
+# Rollback
+
+## Depuis le bootloader
+
+Au démarrage, sélectionner une génération précédente NixOS.
+
+## Depuis le système en cours
+
+```sh
+sudo nixos-rebuild switch --rollback
+```
+
+## Vérifier la génération active
+
+```sh
+nixos-rebuild list-generations
+```

--- a/docs/operations/tailscale.md
+++ b/docs/operations/tailscale.md
@@ -1,0 +1,21 @@
+# Tailscale
+
+Le service est activé dans la configuration commune (`services.tailscale.enable = true`).
+
+## Joindre le tailnet
+
+```sh
+sudo tailscale up --auth-key=<VOTRE_CLE>
+```
+
+## Vérifier l'état
+
+```sh
+systemctl status tailscaled
+sudo tailscale status
+```
+
+## À compléter
+
+- Politique d'expiration des clés.
+- Paramètres optionnels (`--accept-routes`, `--ssh`, tags, etc.) selon vos besoins.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,30 @@
+# Dépannage
+
+## Commandes de base
+
+```sh
+nix flake show
+nix flake check --no-build
+git status
+```
+
+## Activer une trace détaillée
+
+```sh
+sudo nixos-rebuild dry-activate --flake .#desktop --show-trace
+```
+
+## Vérifier les règles Hyprland
+
+```sh
+bash scripts/check-hyprland-rules.sh
+```
+
+## Symptômes courants
+
+| Symptôme | Vérification |
+|---|---|
+| Erreur flake | `nix flake check --no-build` |
+| Erreur host introuvable | `nix flake show` puis vérifier `nixosConfigurations` |
+| Problème Hyprland rules | script `check-hyprland-rules.sh` |
+| Réseau/Tailscale | `systemctl status tailscaled` puis `tailscale status` |

--- a/docs/operations/update-flake.md
+++ b/docs/operations/update-flake.md
@@ -1,0 +1,21 @@
+# Mise à jour de la flake
+
+## Mettre à jour tous les inputs
+
+```sh
+nix flake update
+```
+
+## Mettre à jour un input précis
+
+```sh
+nix flake lock --update-input nixpkgs
+```
+
+## Vérifier après mise à jour
+
+```sh
+nix flake check --no-build
+sudo nixos-rebuild dry-activate --flake .#desktop
+sudo nixos-rebuild dry-activate --flake .#laptop
+```

--- a/docs/reference/aliases.md
+++ b/docs/reference/aliases.md
@@ -1,0 +1,24 @@
+# Aliases
+
+## Aliases partagés (`hm/zsh.nix`)
+
+| Alias | Commande |
+|---|---|
+| `doom` | `~/.config/emacs/bin/doom` |
+| `dupdate` | `sudo nixos-rebuild switch --flake ~/Documents/nix-configuration#desktop --show-trace` |
+| `lupdate` | `sudo nixos-rebuild switch --flake ~/Documents/nix-configuration#laptop --show-trace` |
+| `v4l2loopback-ctl0` | config `/dev/video0` |
+| `v4l2loopback-ctl1` | config `/dev/video1` |
+| `skb` | switch layout clavier Hyprland |
+| `extract` | `~/extract.sh` |
+| `dpms` | cycle dpms Hyprland |
+| `4000` | température Hyprsunset 4000K |
+| `identity` | reset température Hyprsunset |
+
+## Aliases spécifiques host
+
+| Host | Alias | Commande |
+|---|---|---|
+| desktop | `valheim` | lance Valheim avec gamemoderun/mangohud |
+| laptop | `ac` | `sudo tlp ac` |
+| laptop | `bat` | `sudo tlp start` |

--- a/docs/reference/inputs.md
+++ b/docs/reference/inputs.md
@@ -1,0 +1,22 @@
+# Inputs de la flake
+
+## Inputs déclarés
+
+| Input | Source | Usage principal |
+|---|---|---|
+| `nixpkgs` | `github:NixOS/nixpkgs/nixos-unstable` | base packages/modules |
+| `nixpkgs-stable` | `github:nixos/nixpkgs/nixos-25.11` | paquets stables additionnels |
+| `nixpkgs-unstable` | `github:NixOS/nixpkgs/nixpkgs-unstable` | paquets récents (desktop) |
+| `home-manager` | `github:nix-community/home-manager` | configuration utilisateur |
+| `stylix` | `github:danth/stylix` | theming |
+| `pipewire-screenaudio` | `github:IceDBorn/pipewire-screenaudio` | dépendance potentielle navigateur/audio |
+| `codex-cli-nix` | `github:sadjow/codex-cli-nix` | package `codex` |
+| `zen-browser` | `github:youwen5/zen-browser-flake` | package navigateur |
+
+## Vérifier les versions lockées
+
+```sh
+nix flake metadata
+```
+
+ou consulter directement `flake.lock`.

--- a/docs/reference/package-groups.md
+++ b/docs/reference/package-groups.md
@@ -1,0 +1,40 @@
+# Groupes de paquets
+
+`packages/common.nix` regroupe les paquets par listes `pkgs2_*`.
+
+## Vue rapide
+
+| Groupe | Thème |
+|---|---|
+| `pkgs2_0` | base utilitaires/audio |
+| `pkgs2_1` | productivité/multimédia |
+| `pkgs2_2` | thème GTK |
+| `pkgs2_3` | clipboard/spell |
+| `pkgs2_6` | éditeurs |
+| `pkgs2_7` | outils terminal/système |
+| `pkgs2_8` | calculatrices |
+| `pkgs2_9` | caméra/archives |
+| `pkgs2_10` | vidéo |
+| `pkgs2_11` | virtualisation |
+| `pkgs2_12` | PDF/TeX |
+| `pkgs2_13` | monitoring |
+| `pkgs2_14` | réseau/dev |
+| `pkgs2_15` | navigateurs |
+| `pkgs2_16` | communication |
+| `pkgs2_17` | conversion docs |
+| `pkgs2_18` | téléchargement |
+| `pkgs2_19` | finance |
+| `pkgs2_20` | Python/env |
+| `pkgs2_21` | médias/audio |
+| `pkgs2_22` | compression |
+| `pkgs2_23` | utilitaires divers |
+| `pkgs2_24` | Wine |
+| `pkgs2_25` | screenshots/wallpaper |
+| `pkgs2_26` | luminosité |
+| `pkgs2_27` | gaming |
+| `pkgs2_28` | outils Xorg |
+
+## Paquets spécifiques host
+
+- `packages/desktop.nix` : groupes `pkgs3_*`.
+- `packages/laptop.nix` : `powertop`.

--- a/docs/reference/ports.md
+++ b/docs/reference/ports.md
@@ -1,0 +1,20 @@
+# Ports
+
+## Desktop
+
+Le host desktop charge les ports depuis `hosts/desktop/ports.nix` pour TCP et UDP.
+
+Ports: `22, 80, 91, 443, 444, 4747, 5037, 5555, 6379, 7777, 7878, 8080, 8501, 8777, 9100, 2268, 47984, 47989, 47998, 47999, 48010, 48100, 48200, 47990, 48000, 48002, 8989, 8096, 8211, 27015`.
+
+SSH écoute explicitement sur `2268`.
+
+## Laptop
+
+Ports TCP/UDP autorisés:
+
+- `80`
+- `91`
+- `443`
+- `444`
+- `8501`
+- `9100`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,112 @@
+site_name: "NixOS Flake - Documentation"
+site_description: "Documentation de la configuration NixOS (desktop/laptop)"
+repo_url: "https://github.com/LAlto96/nixos"
+repo_name: "LAlto96/nixos"
+edit_uri: "edit/main/"
+
+theme:
+  name: material
+  language: fr
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Français:
+      - Accueil: index.md
+      - Démarrage: getting-started.md
+      - Architecture:
+          - Vue d'ensemble: architecture/overview.md
+          - Flake: architecture/flake.md
+          - Graphe des modules: architecture/module-graph.md
+          - Arborescence du dépôt: architecture/repository-layout.md
+      - Hosts:
+          - Desktop: hosts/desktop.md
+          - Laptop: hosts/laptop.md
+          - Ajouter un host: hosts/adding-a-host.md
+      - Modules:
+          - common-modules.nix: modules/common-modules.md
+          - Configuration système: modules/system.md
+          - Home Manager: modules/home-manager.md
+          - Paquets: modules/packages.md
+          - Overlays: modules/overlays.md
+          - GPU: modules/gpu.md
+          - Hyprland: modules/hyprland.md
+          - Stylix: modules/stylix.md
+          - Services: modules/services.md
+      - Opérations:
+          - Rebuild: operations/rebuild.md
+          - Mise à jour flake: operations/update-flake.md
+          - Rollback: operations/rollback.md
+          - Dépannage: operations/troubleshooting.md
+          - Tailscale: operations/tailscale.md
+      - Développement:
+          - Checks: development/checks.md
+          - CI: development/ci.md
+          - Conventions: development/conventions.md
+          - Workflow documentation: development/documentation-workflow.md
+      - Référence:
+          - Aliases: reference/aliases.md
+          - Ports: reference/ports.md
+          - Groupes de paquets: reference/package-groups.md
+          - Inputs flake: reference/inputs.md
+  - English:
+      - Home: en/index.md
+      - Getting started: en/getting-started.md
+      - Architecture:
+          - Overview: en/architecture/overview.md
+          - Flake: en/architecture/flake.md
+          - Module graph: en/architecture/module-graph.md
+          - Repository layout: en/architecture/repository-layout.md
+      - Hosts:
+          - Desktop: en/hosts/desktop.md
+          - Laptop: en/hosts/laptop.md
+          - Adding a host: en/hosts/adding-a-host.md
+      - Modules:
+          - common-modules.nix: en/modules/common-modules.md
+          - System: en/modules/system.md
+          - Home Manager: en/modules/home-manager.md
+          - Packages: en/modules/packages.md
+          - Overlays: en/modules/overlays.md
+          - GPU: en/modules/gpu.md
+          - Hyprland: en/modules/hyprland.md
+          - Stylix: en/modules/stylix.md
+          - Services: en/modules/services.md
+      - Operations:
+          - Rebuild: en/operations/rebuild.md
+          - Update flake: en/operations/update-flake.md
+          - Rollback: en/operations/rollback.md
+          - Troubleshooting: en/operations/troubleshooting.md
+          - Tailscale: en/operations/tailscale.md
+      - Development:
+          - Checks: en/development/checks.md
+          - CI: en/development/ci.md
+          - Conventions: en/development/conventions.md
+          - Documentation workflow: en/development/documentation-workflow.md
+      - Reference:
+          - Aliases: en/reference/aliases.md
+          - Ports: en/reference/ports.md
+          - Package groups: en/reference/package-groups.md
+          - Flake inputs: en/reference/inputs.md


### PR DESCRIPTION
### Motivation

- Introduce a structured, bilingual (fr/en) documentation site using MkDocs to replace the monolithic docs and make the flake usage and repo layout clearer. 
- Provide developer-facing guidance (checks, CI recommendations, conventions, documentation workflow) and operational instructions for common NixOS/flake tasks. 

### Description

- Add `mkdocs.yml` and a full docs tree under `docs/` and `docs/en/` covering architecture, hosts, modules, operations, development, and reference pages. 
- Replace and simplify `README.md` content to present the repo as a flake-based NixOS configuration and include concise commands (`mkdocs serve`, `mkdocs build`, `nix flake show`, `nix flake check --no-build`, `sudo nixos-rebuild switch --flake .#desktop`, `sudo nixos-rebuild switch --flake .#laptop`). 
- Document flake inputs/outputs, module graph and repository layout, host-specific notes for `desktop` and `laptop`, and operational guidance (rebuild, rollback, update flake, Tailscale). 
- Add developer guidance pages: `development/checks.md`, `development/ci.md`, `development/conventions.md`, and `development/documentation-workflow.md`, and include mermaid diagrams and copy-paste command snippets. 

### Testing

- Built the MkDocs site locally with `mkdocs build` to validate the documentation renders correctly and the site build completed successfully. 
- Ran `nix flake check --no-build` to validate flake outputs and it completed successfully. 
- Executed the Hyprland rules validator with `bash scripts/check-hyprland-rules.sh` and it returned success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef4784c22c83319f474f6d6585d2c3)