### PR TITLE
chore(nix): align flake with stable channel and document pkgs/unstable policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ La documentation est maintenant structurée avec **MkDocs Material** et disponib
 ### Lancer la doc en local
 
 ```sh
-mkdocs serve
+nix-shell mkdocs.nix --run "mkdocs serve"
 ```
 
 ### Construire la doc statique
 
 ```sh
-mkdocs build
+nix-shell mkdocs.nix --run "mkdocs build"
 ```
 
 ## Commandes NixOS usuelles

--- a/common-modules.nix
+++ b/common-modules.nix
@@ -3,8 +3,11 @@ with inputs; [
   stylix.nixosModules.stylix
   ./configuration.nix
   home-manager.nixosModules.home-manager
-  {
+  ({ pkgs-unstable, ... }: {
     nixpkgs.overlays = [ imageMagickCompatOverlay ];
+    home-manager.extraSpecialArgs = {
+      inherit inputs pkgs-unstable;
+    };
     home-manager.sharedModules = [
       {
         nixpkgs.overlays = [ imageMagickCompatOverlay ];
@@ -12,5 +15,5 @@ with inputs; [
     ];
     home-manager.useGlobalPkgs = false;
     home-manager.useUserPackages = true;
-  }
+  })
 ]

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, nixpkgs-stable, inputs, lib, ... }:
+{ config, pkgs, inputs, lib, ... }:
 
 {
   home-manager.backupFileExtension = "backup";

--- a/docs/architecture/flake.md
+++ b/docs/architecture/flake.md
@@ -5,8 +5,7 @@
 La flake déclare notamment:
 
 - `nixpkgs` (canal principal)
-- `nixpkgs-stable`
-- `nixpkgs-unstable`
+- `nixpkgs-unstable` (exceptions explicites)
 - `home-manager`
 - `stylix`
 - `zen-browser`
@@ -24,6 +23,6 @@ Voir aussi la page [Inputs](../reference/inputs.md).
 
 ## Spécificités
 
-- `desktop` reçoit `pkgs-stable` **et** `pkgs-unstable` dans `specialArgs`.
-- `laptop` reçoit `pkgs-stable` dans `specialArgs`.
+- `nixpkgs` est le canal stable par défaut.
+- `desktop` et `laptop` reçoivent `pkgs-unstable` dans `specialArgs` pour les paquets rapides explicitement sélectionnés.
 - Les deux hosts utilisent `commonModules` puis ajoutent leur module host.

--- a/docs/architecture/flake.md
+++ b/docs/architecture/flake.md
@@ -4,10 +4,10 @@
 
 La flake déclare notamment:
 
-- `nixpkgs` (canal principal)
+- `nixpkgs` (canal stable principal, branche `nixos-25.11`)
 - `nixpkgs-unstable` (exceptions explicites)
-- `home-manager`
-- `stylix`
+- `home-manager` (branche `release-25.11`, suit `nixpkgs`)
+- `stylix` (branche `release-25.11`)
 - `zen-browser`
 - `pipewire-screenaudio`
 - `codex-cli-nix`
@@ -25,4 +25,6 @@ Voir aussi la page [Inputs](../reference/inputs.md).
 
 - `nixpkgs` est le canal stable par défaut.
 - `desktop` et `laptop` reçoivent `pkgs-unstable` dans `specialArgs` pour les paquets rapides explicitement sélectionnés.
+- Les modules Home Manager reçoivent aussi `pkgs-unstable` via `home-manager.extraSpecialArgs`.
+- Les paquets doivent venir de `pkgs` par défaut; les exceptions depuis `pkgs-unstable` restent regroupées dans des listes explicites (`unstableGamingPkgs`, `unstableCompatibilityPkgs`, etc.).
 - Les deux hosts utilisent `commonModules` puis ajoutent leur module host.

--- a/docs/development/conventions.md
+++ b/docs/development/conventions.md
@@ -5,6 +5,8 @@
 - Éviter les refactors de masse sans besoin fonctionnel.
 - Ajouter les nouveaux modules via imports explicites.
 - Garder la séparation `commun` / `host`.
+- Garder `nixpkgs`, `home-manager` et `stylix` sur la branche stable courante.
+- Ajouter les paquets depuis `pkgs` par défaut; réserver `pkgs-unstable` aux exceptions nommées et regroupées.
 
 ## Documentation
 

--- a/docs/development/documentation-workflow.md
+++ b/docs/development/documentation-workflow.md
@@ -7,13 +7,13 @@
 3. Prévisualiser localement.
 
 ```sh
-mkdocs serve
+nix-shell mkdocs.nix --run "mkdocs serve"
 ```
 
 ## Build local
 
 ```sh
-mkdocs build
+nix-shell mkdocs.nix --run "mkdocs build"
 ```
 
 Toute nouvelle documentation doit être ajoutée dans les pages structurées de `docs/`.

--- a/docs/en/architecture/flake.md
+++ b/docs/en/architecture/flake.md
@@ -2,10 +2,10 @@
 
 ## Main inputs
 
-- `nixpkgs`
-- `nixpkgs-unstable`
-- `home-manager`
-- `stylix`
+- `nixpkgs` (main stable channel, `nixos-25.11`)
+- `nixpkgs-unstable` (explicit exceptions)
+- `home-manager` (`release-25.11`, follows `nixpkgs`)
+- `stylix` (`release-25.11`)
 - `zen-browser`
 - `pipewire-screenaudio`
 - `codex-cli-nix`
@@ -16,3 +16,11 @@
 - `nixosConfigurations.laptop`
 - `overlays.imagemagick-compat`
 - `checks.x86_64-linux.hyprland-rules`
+
+## Channel Policy
+
+- `nixpkgs` is the default stable channel.
+- `desktop` and `laptop` receive `pkgs-unstable` through `specialArgs` for explicitly selected fast-moving packages.
+- Home Manager modules also receive `pkgs-unstable` through `home-manager.extraSpecialArgs`.
+- Packages should come from `pkgs` by default; unstable exceptions stay in clearly named lists such as `unstableGamingPkgs` and `unstableCompatibilityPkgs`.
+- Both hosts use `commonModules`, then append their host module.

--- a/docs/en/architecture/flake.md
+++ b/docs/en/architecture/flake.md
@@ -3,7 +3,6 @@
 ## Main inputs
 
 - `nixpkgs`
-- `nixpkgs-stable`
 - `nixpkgs-unstable`
 - `home-manager`
 - `stylix`

--- a/docs/en/development/conventions.md
+++ b/docs/en/development/conventions.md
@@ -3,3 +3,5 @@
 - Keep docs concise and actionable.
 - Keep commands copy-paste friendly.
 - Avoid documenting behavior not present in the repo.
+- Keep `nixpkgs`, `home-manager`, and `stylix` on the current stable branch.
+- Add packages from `pkgs` by default; reserve `pkgs-unstable` for named grouped exceptions.

--- a/docs/en/development/documentation-workflow.md
+++ b/docs/en/development/documentation-workflow.md
@@ -5,5 +5,5 @@
 3. Preview locally:
 
 ```sh
-mkdocs serve
+nix-shell mkdocs.nix --run "mkdocs serve"
 ```

--- a/docs/en/hosts/adding-a-host.md
+++ b/docs/en/hosts/adding-a-host.md
@@ -1,9 +1,44 @@
 # Adding a host
 
-1. Create `hosts/<new-host>/default.nix` and import required hardware/GPU/package modules.
-2. Declare the host under `nixosConfigurations` in `flake.nix`.
-3. Wire Home Manager user (`home-manager.users.<user>`) and trusted user.
-4. Validate:
+## 1. Create the Host Module
+
+Create `hosts/<new-host>/default.nix` and import:
+
+- the hardware configuration file,
+- the required GPU modules,
+- host-specific packages,
+- optional service/driver modules.
+
+## 2. Declare the Host in `flake.nix`
+
+```nix
+nixosConfigurations.<new-host> = nixpkgs.lib.nixosSystem {
+  specialArgs = {
+    inherit inputs;
+    pkgs-unstable = import nixpkgs-unstable {
+      inherit system;
+      config.allowUnfree = true;
+    };
+  };
+  modules = commonModules ++ [
+    { nixpkgs.hostPlatform = system; }
+    ./hosts/<new-host>
+  ];
+};
+```
+
+`pkgs-unstable` is passed for explicit package exceptions only. Default package selections should still use stable `pkgs`.
+
+## 3. Add the Home Manager User
+
+In the host module:
+
+```nix
+home-manager.users.<user> = import ../../home-<host>.nix;
+nix.settings.trusted-users = [ "<user>" ];
+```
+
+## 4. Validate
 
 ```sh
 nix flake show

--- a/docs/en/modules/packages.md
+++ b/docs/en/modules/packages.md
@@ -1,5 +1,28 @@
 # Package modules
 
-- `packages/common.nix`: shared package groups (`pkgs2_*`) + Steam/Gamescope.
-- `packages/desktop.nix`: desktop-focused extras (DAW, video, virtualization, benchmarks).
-- `packages/laptop.nix`: laptop additions (`powertop`).
+## `packages/common.nix`
+
+- Enables Java, Steam, and Gamescope.
+- Builds `environment.systemPackages` from `pkgs2_*` groups.
+- Adds `unstableGamingPkgs` from `pkgs-unstable` for fast-moving gaming exceptions.
+- Adds `unstableCompatibilityPkgs` from `pkgs-unstable` for packages missing from stable.
+
+## `packages/desktop.nix`
+
+Adds desktop-focused packages:
+
+- audio/production (`reaper`, `yabridge`)
+- video (`davinci-resolve`)
+- virtualization (`quickemu`)
+- benchmark/overclocking (`phoronix-test-suite`)
+- Steam/gaming utilities (`sgdboop` from stable, `alvr` and `nvidia_oc` from unstable)
+
+## `packages/laptop.nix`
+
+Adds `powertop`.
+
+## Package Policy
+
+- Add packages to a `with pkgs; [...]` list by default.
+- Use `pkgs-unstable` only when a package is missing from stable or needs a faster-moving branch.
+- Keep every unstable exception in a named list that explains the reason (`unstableGamingPkgs`, `unstableCompatibilityPkgs`, `unstableGamingDesktopPkgs`).

--- a/docs/en/operations/update-flake.md
+++ b/docs/en/operations/update-flake.md
@@ -1,7 +1,22 @@
 # Update flake
 
+## Update Inputs
+
 ```sh
 nix flake update
 nix flake lock --update-input nixpkgs
+```
+
+## Branch Policy
+
+- Keep `nixpkgs`, `home-manager`, and `stylix` aligned on the current stable release.
+- `nixpkgs-unstable` can be updated separately for explicit exceptions.
+- A stable release change should update the related branches in `flake.nix`, then refresh the lock.
+
+## Validate
+
+```sh
 nix flake check --no-build
+sudo nixos-rebuild dry-activate --flake .#desktop
+sudo nixos-rebuild dry-activate --flake .#laptop
 ```

--- a/docs/en/reference/inputs.md
+++ b/docs/en/reference/inputs.md
@@ -1,11 +1,19 @@
 # Flake inputs
 
-Declared in `flake.nix`:
+## Declared inputs
 
-- `nixpkgs`
-- `nixpkgs-unstable`
-- `home-manager`
-- `stylix`
-- `pipewire-screenaudio`
-- `codex-cli-nix`
-- `zen-browser`
+| Input | Source | Main usage |
+|---|---|---|
+| `nixpkgs` | `github:nixos/nixpkgs/nixos-25.11` | default stable package/module base |
+| `nixpkgs-unstable` | `github:NixOS/nixpkgs/nixpkgs-unstable` | explicit fast-moving exceptions, mainly gaming/compatibility |
+| `home-manager` | `github:nix-community/home-manager/release-25.11` | user configuration, follows `nixpkgs` |
+| `stylix` | `github:danth/stylix/release-25.11` | theming aligned with the stable branch |
+| `pipewire-screenaudio` | `github:IceDBorn/pipewire-screenaudio` | potential browser/audio dependency |
+| `codex-cli-nix` | `github:sadjow/codex-cli-nix` | `codex` package |
+| `zen-browser` | `github:youwen5/zen-browser-flake` | browser package |
+
+## Branch Policy
+
+- Keep `nixpkgs`, `home-manager`, and `stylix` aligned on the same stable release.
+- Do not add a second stable nixpkgs input: `nixpkgs` is already the stable base.
+- Use `nixpkgs-unstable` only for named, localized exceptions.

--- a/docs/en/reference/inputs.md
+++ b/docs/en/reference/inputs.md
@@ -3,7 +3,6 @@
 Declared in `flake.nix`:
 
 - `nixpkgs`
-- `nixpkgs-stable`
 - `nixpkgs-unstable`
 - `home-manager`
 - `stylix`

--- a/docs/en/reference/package-groups.md
+++ b/docs/en/reference/package-groups.md
@@ -1,8 +1,13 @@
 # Package groups
 
-Shared package groups are maintained in `packages/common.nix` under `pkgs2_*` lists.
+Shared package groups are maintained in `packages/common.nix` under `pkgs2_*` lists. Those lists use stable `pkgs` by default.
+
+Common unstable exception lists:
+
+- `unstableGamingPkgs`: gaming packages from `pkgs-unstable`
+- `unstableCompatibilityPkgs`: packages missing from stable, sourced from `pkgs-unstable`
 
 Host-specific package additions:
 
-- `packages/desktop.nix` (`pkgs3_*` lists)
+- `packages/desktop.nix` (`pkgs3_*` lists + `unstableGamingDesktopPkgs`)
 - `packages/laptop.nix`

--- a/docs/hosts/adding-a-host.md
+++ b/docs/hosts/adding-a-host.md
@@ -15,7 +15,7 @@ Créer `hosts/<nouveau-host>/default.nix` puis importer:
 nixosConfigurations.<nouveau-host> = nixpkgs.lib.nixosSystem {
   specialArgs = {
     inherit inputs;
-    pkgs-stable = import nixpkgs-stable {
+    pkgs-unstable = import nixpkgs-unstable {
       inherit system;
       config.allowUnfree = true;
     };

--- a/docs/modules/packages.md
+++ b/docs/modules/packages.md
@@ -5,6 +5,7 @@
 - Active Java, Steam et Gamescope.
 - Construit `environment.systemPackages` à partir de groupes `pkgs2_*`.
 - Ajoute `unstableGamingPkgs` depuis `pkgs-unstable` pour les exceptions gaming rapides.
+- Ajoute `unstableCompatibilityPkgs` depuis `pkgs-unstable` pour les paquets absents de stable.
 
 ## `packages/desktop.nix`
 
@@ -15,6 +16,12 @@ Ajoute des paquets orientés desktop:
 - virtualisation (`quickemu`)
 - bench/OC (`phoronix-test-suite`)
 - outils Steam/gaming (`sgdboop` depuis stable, `alvr` et `nvidia_oc` depuis unstable)
+
+## Policy paquets
+
+- Ajouter un paquet dans une liste `with pkgs; [...]` par défaut.
+- Utiliser `pkgs-unstable` seulement quand le paquet est absent de stable ou doit suivre un rythme plus rapide.
+- Regrouper chaque exception unstable dans une liste nommée qui explique la raison (`unstableGamingPkgs`, `unstableCompatibilityPkgs`, `unstableGamingDesktopPkgs`).
 
 ## `packages/laptop.nix`
 

--- a/docs/modules/packages.md
+++ b/docs/modules/packages.md
@@ -4,7 +4,7 @@
 
 - Active Java, Steam et Gamescope.
 - Construit `environment.systemPackages` à partir de groupes `pkgs2_*`.
-- Ajoute `stablepkgs` depuis `pkgs-stable`.
+- Ajoute `unstableGamingPkgs` depuis `pkgs-unstable` pour les exceptions gaming rapides.
 
 ## `packages/desktop.nix`
 
@@ -13,8 +13,8 @@ Ajoute des paquets orientés desktop:
 - audio/prod (`reaper`, `yabridge`)
 - vidéo (`davinci-resolve`)
 - virtualisation (`quickemu`)
-- bench/OC (`nvidia_oc`, `phoronix-test-suite`)
-- outils gaming depuis stable (`sgdboop`, `alvr`)
+- bench/OC (`phoronix-test-suite`)
+- outils Steam/gaming (`sgdboop` depuis stable, `alvr` et `nvidia_oc` depuis unstable)
 
 ## `packages/laptop.nix`
 

--- a/docs/operations/update-flake.md
+++ b/docs/operations/update-flake.md
@@ -12,6 +12,12 @@ nix flake update
 nix flake lock --update-input nixpkgs
 ```
 
+## Policy branches
+
+- `nixpkgs`, `home-manager` et `stylix` restent alignés sur la release stable courante.
+- `nixpkgs-unstable` peut être mis à jour séparément pour les exceptions explicites.
+- Un changement de release stable doit mettre à jour les branches concernées dans `flake.nix`, puis le lock.
+
 ## Vérifier après mise à jour
 
 ```sh

--- a/docs/reference/inputs.md
+++ b/docs/reference/inputs.md
@@ -4,10 +4,10 @@
 
 | Input | Source | Usage principal |
 |---|---|---|
-| `nixpkgs` | `github:nixos/nixpkgs/nixos-25.11` | base stable packages/modules |
-| `nixpkgs-unstable` | `github:NixOS/nixpkgs/nixpkgs-unstable` | exceptions rapides explicites, principalement gaming |
-| `home-manager` | `github:nix-community/home-manager` | configuration utilisateur |
-| `stylix` | `github:danth/stylix` | theming |
+| `nixpkgs` | `github:nixos/nixpkgs/nixos-25.11` | base stable par défaut pour les packages/modules |
+| `nixpkgs-unstable` | `github:NixOS/nixpkgs/nixpkgs-unstable` | exceptions rapides explicites, principalement gaming/compatibilité |
+| `home-manager` | `github:nix-community/home-manager/release-25.11` | configuration utilisateur, suit `nixpkgs` |
+| `stylix` | `github:danth/stylix/release-25.11` | theming aligné sur la branche stable |
 | `pipewire-screenaudio` | `github:IceDBorn/pipewire-screenaudio` | dépendance potentielle navigateur/audio |
 | `codex-cli-nix` | `github:sadjow/codex-cli-nix` | package `codex` |
 | `zen-browser` | `github:youwen5/zen-browser-flake` | package navigateur |
@@ -19,3 +19,9 @@ nix flake metadata
 ```
 
 ou consulter directement `flake.lock`.
+
+## Policy branches
+
+- Garder `nixpkgs`, `home-manager` et `stylix` alignés sur la même release stable.
+- Ne pas ajouter de nouvel input stable parallèle: `nixpkgs` est déjà la base stable.
+- Utiliser `nixpkgs-unstable` uniquement pour une exception nommée et localisée.

--- a/docs/reference/inputs.md
+++ b/docs/reference/inputs.md
@@ -4,9 +4,8 @@
 
 | Input | Source | Usage principal |
 |---|---|---|
-| `nixpkgs` | `github:NixOS/nixpkgs/nixos-unstable` | base packages/modules |
-| `nixpkgs-stable` | `github:nixos/nixpkgs/nixos-25.11` | paquets stables additionnels |
-| `nixpkgs-unstable` | `github:NixOS/nixpkgs/nixpkgs-unstable` | paquets récents (desktop) |
+| `nixpkgs` | `github:nixos/nixpkgs/nixos-25.11` | base stable packages/modules |
+| `nixpkgs-unstable` | `github:NixOS/nixpkgs/nixpkgs-unstable` | exceptions rapides explicites, principalement gaming |
 | `home-manager` | `github:nix-community/home-manager` | configuration utilisateur |
 | `stylix` | `github:danth/stylix` | theming |
 | `pipewire-screenaudio` | `github:IceDBorn/pipewire-screenaudio` | dépendance potentielle navigateur/audio |

--- a/docs/reference/package-groups.md
+++ b/docs/reference/package-groups.md
@@ -28,11 +28,10 @@
 | `pkgs2_21` | médias/audio |
 | `pkgs2_22` | compression |
 | `pkgs2_23` | utilitaires divers |
-| `pkgs2_24` | Wine |
 | `pkgs2_25` | screenshots/wallpaper |
 | `pkgs2_26` | luminosité |
-| `pkgs2_27` | gaming |
 | `pkgs2_28` | outils Xorg |
+| `unstableGamingPkgs` | exceptions gaming depuis unstable |
 
 ## Paquets spécifiques host
 

--- a/docs/reference/package-groups.md
+++ b/docs/reference/package-groups.md
@@ -31,9 +31,10 @@
 | `pkgs2_25` | screenshots/wallpaper |
 | `pkgs2_26` | luminosité |
 | `pkgs2_28` | outils Xorg |
-| `unstableGamingPkgs` | exceptions gaming depuis unstable |
+| `unstableGamingPkgs` | exceptions gaming depuis `pkgs-unstable` |
+| `unstableCompatibilityPkgs` | exceptions absentes de stable depuis `pkgs-unstable` |
 
 ## Paquets spécifiques host
 
-- `packages/desktop.nix` : groupes `pkgs3_*`.
+- `packages/desktop.nix` : groupes `pkgs3_*` et `unstableGamingDesktopPkgs`.
 - `packages/laptop.nix` : `powertop`.

--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1777054843,
-        "narHash": "sha256-aiuiKK6xJu5inj/RTmSl9S3jDC6RzNsKfNJ700MRPNY=",
+        "lastModified": 1778282716,
+        "narHash": "sha256-fHo9PlYWu970hmdVkDB2Jqeu0VmhmqQ5iKOnPjf/I1E=",
         "owner": "sadjow",
         "repo": "codex-cli-nix",
-        "rev": "fc382bef14dcb9873769bdcb4d3b943ef2606489",
+        "rev": "7f0f3802287581e04501e2fea26b56d63df18ebd",
         "type": "github"
       },
       "original": {
@@ -90,11 +90,11 @@
     "firefox-gnome-theme": {
       "flake": false,
       "locked": {
-        "lastModified": 1775176642,
-        "narHash": "sha256-2veEED0Fg7Fsh81tvVDNYR6SzjqQxa7hbi18Jv4LWpM=",
+        "lastModified": 1764873433,
+        "narHash": "sha256-1XPewtGMi+9wN9Ispoluxunw/RwozuTRVuuQOmxzt+A=",
         "owner": "rafaelmardojai",
         "repo": "firefox-gnome-theme",
-        "rev": "179704030c5286c729b5b0522037d1d51341022c",
+        "rev": "f7ffd917ac0d253dbd6a3bf3da06888f57c69f92",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1767609335,
+        "narHash": "sha256-feveD98mQpptwrAEggBQKJTYbvwwglSbOv53uCfH9PY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "250481aafeb741edfe23d29195671c19b36b6dca",
         "type": "github"
       },
       "original": {
@@ -161,18 +161,20 @@
     "gnome-shell": {
       "flake": false,
       "locked": {
+        "host": "gitlab.gnome.org",
         "lastModified": 1767737596,
         "narHash": "sha256-eFujfIUQDgWnSJBablOuG+32hCai192yRdrNHTv0a+s=",
         "owner": "GNOME",
         "repo": "gnome-shell",
         "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-        "type": "github"
+        "type": "gitlab"
       },
       "original": {
+        "host": "gitlab.gnome.org",
         "owner": "GNOME",
+        "ref": "gnome-49",
         "repo": "gnome-shell",
-        "rev": "ef02db02bf0ff342734d525b5767814770d85b49",
-        "type": "github"
+        "type": "gitlab"
       }
     },
     "home-manager": {
@@ -182,26 +184,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1777151655,
-        "narHash": "sha256-Th3a5OZyEy4kCoyLfefnt+2dwRIrFQqYgMsayF9qzFw=",
+        "lastModified": 1777851538,
+        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6f59831b23d03bbf4fbd13ad167ae25da294cc14",
+        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "release-25.11",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -211,29 +214,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1776734388,
-        "narHash": "sha256-vl3dkhlE5gzsItuHoEMVe+DlonsK+0836LIRDnm6MXQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "10e7ad5bbcb421fe07e3a4ad53a634b0cd57ffac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -245,16 +232,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776877367,
-        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
-        "owner": "NixOS",
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "owner": "nixos",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -277,16 +264,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -303,11 +290,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775228139,
-        "narHash": "sha256-ebbeHmg+V7w8050bwQOuhmQHoLOEOfqKzM1KgCTexK4=",
+        "lastModified": 1767886815,
+        "narHash": "sha256-pB2BBv6X9cVGydEV/9Y8+uGCvuYJAlsprs1v1QHjccA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "601971b9c89e0304561977f2c28fa25e73aa7132",
+        "rev": "4ff84374d77ff62e2e13a46c33bfeb73590f9fef",
         "type": "github"
       },
       "original": {
@@ -339,7 +326,6 @@
         "codex-cli-nix": "codex-cli-nix",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-stable": "nixpkgs-stable",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "pipewire-screenaudio": "pipewire-screenaudio",
         "stylix": "stylix",
@@ -358,21 +344,23 @@
         "nixpkgs": "nixpkgs_4",
         "nur": "nur",
         "systems": "systems_2",
+        "tinted-foot": "tinted-foot",
         "tinted-kitty": "tinted-kitty",
         "tinted-schemes": "tinted-schemes",
         "tinted-tmux": "tinted-tmux",
         "tinted-zed": "tinted-zed"
       },
       "locked": {
-        "lastModified": 1776893932,
-        "narHash": "sha256-AFD5cf9eNqXq1brHS63xeZy2xKZMgG9J86XJ9I2eLn8=",
+        "lastModified": 1778105055,
+        "narHash": "sha256-SWz0cVHEGFb2rSszCaQ7nmuM9q7Cq3xbsg+DAg0N9jo=",
         "owner": "danth",
         "repo": "stylix",
-        "rev": "84971726c7ef0bb3669a5443e151cc226e65c518",
+        "rev": "68b1ff44196f4f593d0cd837ffb2a088c2870055",
         "type": "github"
       },
       "original": {
         "owner": "danth",
+        "ref": "release-25.11",
         "repo": "stylix",
         "type": "github"
       }
@@ -407,6 +395,23 @@
         "type": "github"
       }
     },
+    "tinted-foot": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1726913040,
+        "narHash": "sha256-+eDZPkw7efMNUf3/Pv0EmsidqdwNJ1TaOum6k7lngDQ=",
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tinted-theming",
+        "repo": "tinted-foot",
+        "rev": "fd1b924b6c45c3e4465e8a849e67ea82933fcbe4",
+        "type": "github"
+      }
+    },
     "tinted-kitty": {
       "flake": false,
       "locked": {
@@ -426,11 +431,11 @@
     "tinted-schemes": {
       "flake": false,
       "locked": {
-        "lastModified": 1772661346,
-        "narHash": "sha256-4eu3LqB9tPqe0Vaqxd4wkZiBbthLbpb7llcoE/p5HT0=",
+        "lastModified": 1767817087,
+        "narHash": "sha256-eGE8OYoK6HzhJt/7bOiNV2cx01IdIrHL7gXgjkHRdNo=",
         "owner": "tinted-theming",
         "repo": "schemes",
-        "rev": "13b5b0c299982bb361039601e2d72587d6846294",
+        "rev": "bd99656235aab343e3d597bf196df9bc67429507",
         "type": "github"
       },
       "original": {
@@ -442,11 +447,11 @@
     "tinted-tmux": {
       "flake": false,
       "locked": {
-        "lastModified": 1772934010,
-        "narHash": "sha256-x+6+4UvaG+RBRQ6UaX+o6DjEg28u4eqhVRM9kpgJGjQ=",
+        "lastModified": 1767489635,
+        "narHash": "sha256-e6nnFnWXKBCJjCv4QG4bbcouJ6y3yeT70V9MofL32lU=",
         "owner": "tinted-theming",
         "repo": "tinted-tmux",
-        "rev": "c3529673a5ab6e1b6830f618c45d9ce1bcdd829d",
+        "rev": "3c32729ccae99be44fe8a125d20be06f8d7d8184",
         "type": "github"
       },
       "original": {
@@ -458,11 +463,11 @@
     "tinted-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1772909925,
-        "narHash": "sha256-jx/5+pgYR0noHa3hk2esin18VMbnPSvWPL5bBjfTIAU=",
+        "lastModified": 1767488740,
+        "narHash": "sha256-wVOj0qyil8m+ouSsVZcNjl5ZR+1GdOOAooAatQXHbuU=",
         "owner": "tinted-theming",
         "repo": "base16-zed",
-        "rev": "b4d3a1b3bcbd090937ef609a0a3b37237af974df",
+        "rev": "11abb0b282ad3786a2aae088d3a01c60916f2e40",
         "type": "github"
       },
       "original": {
@@ -478,11 +483,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777092705,
-        "narHash": "sha256-qKMvM2+eKusg6H6lG2bwDdFjNi1XfEjdLD5xIt8ZgFs=",
+        "lastModified": 1778303188,
+        "narHash": "sha256-zXFSvK80qpI91B7DU9QSExAtafSrz6vzormh2kUi6kQ=",
         "owner": "youwen5",
         "repo": "zen-browser-flake",
-        "rev": "10f5c809db4f8e7badb6d505924ebbaaeefda4e4",
+        "rev": "9346c84657a9cab472bc4ee5a2d65d42a72d5346",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -184,11 +184,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777851538,
-        "narHash": "sha256-Gp8qwTEYNoy2yvmErVGlvLOQvrtEECCAKbonW7VJef8=",
+        "lastModified": 1778401693,
+        "narHash": "sha256-OVHdCqXXUF5UdGkH+FF2ZL06OLZjj2kvP2dIUmzVWoo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "cc09c0f9b7eaa95c2d9827338a5eb03d32505ca5",
+        "rev": "389b83002efc26f1145e89a6a8e6edc5a6435948",
         "type": "github"
       },
       "original": {
@@ -216,11 +216,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1778124196,
-        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,22 +23,22 @@
 
   inputs = {
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-25.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-25.11";
+    # Stable is the default channel. Unstable is reserved for explicit fast-moving package exceptions.
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     pipewire-screenaudio.url = "github:IceDBorn/pipewire-screenaudio";
     codex-cli-nix.url = "github:sadjow/codex-cli-nix";
-    stylix.url = "github:danth/stylix";
+    stylix.url = "github:danth/stylix/release-25.11";
     zen-browser = {
       url = "github:youwen5/zen-browser-flake";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = inputs@{ self, nixpkgs, nixpkgs-stable, nixpkgs-unstable, home-manager, pipewire-screenaudio, stylix, zen-browser, ... }:
+  outputs = inputs@{ self, nixpkgs, nixpkgs-unstable, home-manager, pipewire-screenaudio, stylix, zen-browser, ... }:
     let
       system = "x86_64-linux";
       desktopPorts = import ./hosts/desktop/ports.nix;
@@ -52,7 +52,7 @@
         laptop = nixpkgs.lib.nixosSystem {
           specialArgs = {
             inherit inputs;
-            pkgs-stable = import nixpkgs-stable {
+            pkgs-unstable = import nixpkgs-unstable {
               inherit system;
               config.allowUnfree = true;
             };
@@ -65,10 +65,6 @@
         desktop = nixpkgs.lib.nixosSystem {
           specialArgs = {
             inherit inputs;
-            pkgs-stable = import nixpkgs-stable {
-              inherit system;
-              config.allowUnfree = true;
-            };
             pkgs-unstable = import nixpkgs-unstable {
               inherit system;
               config.allowUnfree = true;

--- a/hm/neovim.nix
+++ b/hm/neovim.nix
@@ -32,7 +32,7 @@
       ''
         nnoremap <F4> :NERDTreeToggle<CR>
       '';
-    initLua =
+    extraLuaConfig =
       ''
         require 'coc'
         vim.g.coq_settings = {auto_start = true}

--- a/home-laptop.nix
+++ b/home-laptop.nix
@@ -1,6 +1,7 @@
 {
   config,
   pkgs,
+  pkgs-unstable,
   lib,
   ...
 }:
@@ -12,9 +13,10 @@
   home.homeDirectory = "/home/laptop";
   nixpkgs.config.allowUnfree = true;
   # Packages that should be installed to the user profile.
-  home.packages = with pkgs; [
+  # Laptop gaming/streaming exceptions use unstable; everything else stays on stable pkgs.
+  home.packages = [
     # mesa
-    moonlight-qt
+    pkgs-unstable.moonlight-qt
   ];
 
   # This value determines the Home Manager release that your

--- a/hyprland.base.conf
+++ b/hyprland.base.conf
@@ -63,12 +63,12 @@ decoration {
         color = rgba(0,0,0,.5)
     }
 }
-windowrule = opacity 0.95 override 0.95 override, match:title .*YouTube.*
-windowrule = opacity 0.95 override 0.95 override, match:title .*Twitch.*
-windowrule = opacity 0.95 override 0.95 override, match:class steam_app_975370
-windowrule = opacity 1.0 override 1.0 override, match:class gambatte_speedrun.exe
-windowrule = opacity 0.95 override 0.95 override, match:initial_title .*Discord Popout.*
-windowrule = opacity 0.95 override 0.95 override, match:initial_title .*Picture-in-Picture.*
+windowrulev2 = opacity 0.95 override 0.95 override, title:.*YouTube.*
+windowrulev2 = opacity 0.95 override 0.95 override, title:.*Twitch.*
+windowrulev2 = opacity 0.95 override 0.95 override, class:steam_app_975370
+windowrulev2 = opacity 1.0 override 1.0 override, class:gambatte_speedrun.exe
+windowrulev2 = opacity 0.95 override 0.95 override, initialTitle:.*Discord Popout.*
+windowrulev2 = opacity 0.95 override 0.95 override, initialTitle:.*Picture-in-Picture.*
 
 
 animations {
@@ -84,11 +84,7 @@ animations {
 }
 
 # Avoid capturing the selection overlay/border in screenshots.
-layerrule {
-    name = no_anim_for_selection
-    no_anim = on
-    match:namespace = selection
-}
+layerrule = noanim, selection
 
 misc {
     force_default_wallpaper = -1
@@ -113,10 +109,10 @@ device {
     sensitivity = -0.5
 }
 
-# Example windowrule (named props + effects)
-# windowrule = float on, match:class ^(kitty)$
-# Example windowrule with multiple props
-# windowrule = float on, match:class ^(kitty)$, match:title ^(kitty)$
+# Example windowrulev2 (named props + effects)
+# windowrulev2 = float, class:^(kitty)$
+# Example windowrulev2 with multiple matchers
+# windowrulev2 = float, class:^(kitty)$, title:^(kitty)$
 # See https://wiki.hyprland.org/Configuring/Window-Rules/ for more
 
 
@@ -126,9 +122,9 @@ $mainMod = SUPER
 bind = $mainMod, semicolon, exec, /home/desktop/Documents/nix-configuration/mute-vesktop.sh toggle
 
 # Clipse clipbloard
-windowrule = float on, match:class (clipse)
-windowrule = size 622 652, match:class (clipse)
-windowrule = stay_focused on, match:class (clipse)
+windowrulev2 = float, class:(clipse)
+windowrulev2 = size 622 652, class:(clipse)
+windowrulev2 = stayfocused, class:(clipse)
 
 bind = SUPER, V, exec, kitty --class clipse -e clipse
 

--- a/mkdocs.nix
+++ b/mkdocs.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+pkgs.mkShell {
+  packages = [
+    (pkgs.python3.withPackages (pythonPackages: with pythonPackages; [
+      mkdocs
+      mkdocs-material
+      pymdown-extensions
+    ]))
+  ];
+}

--- a/packages/common.nix
+++ b/packages/common.nix
@@ -1,10 +1,29 @@
-{ config, pkgs, pkgs-stable, lib, inputs, ... }:
+{ config, pkgs, pkgs-unstable, lib, inputs, ... }:
 
 let
-  # Stable packages from an alternate channel. For example, you might add kicad here.
-  stablepkgs = with pkgs-stable; [
-    # kicad
-    lutris # Gaming platform for Linux games
+  # Policy: pkgs is stable by default. Only explicitly selected fast-moving gaming packages use unstable.
+  unstableGamingPkgs = with pkgs-unstable; [
+    winetricks # Helper to run Windows applications via Wine
+    dosbox-staging # DOS emulator for legacy software
+    wineWow64Packages.waylandFull # Wine package optimized for Wayland
+    radeontop # Monitor Radeon GPU usage in real time
+    gamescope # Compositor for game streaming and recording
+    prismlauncher # Game launcher for Linux
+    mangohud # On-screen display for monitoring game performance
+    heroic # Alternative game launcher (for Epic Games, etc.)
+    protonup-qt # GUI tool to update Proton versions
+    protontricks # Utility for managing Proton tweaks
+    gwe
+    retroarch-full
+    lsfg-vk
+    lsfg-vk-ui
+    steamtinkerlaunch # Tool to tweak Steam launch options
+    vesktop # Communication application (verify details online)
+  ];
+
+  # Compatibility exceptions: these packages are not currently available in stable.
+  unstableCompatibilityPkgs = with pkgs-unstable; [
+    crosspipe # Graphical audio routing tool
   ];
 
   # 2.0: To categorize
@@ -14,20 +33,19 @@ let
     icu
     audacity # Audio editor for recording and editing
     moc # Console audio player
-    proton-vpn # Graphical ProtonVPN client
+    protonvpn-gui # Graphical ProtonVPN client
     proton-pass
     gimp-with-plugins # Image editing software with additional plugins
     usbutils
+    lutris # Gaming platform for Linux games
   ];
 
   # 2.1: General Productivity & Multimedia Tools
   pkgs2_1 = with pkgs; [
     hyprpanel # Hyprland panel integration from nixpkgs
     hyprsunset
-    winetricks # Helper to run Windows applications via Wine
     onlyoffice-desktopeditors # Office suite for document editing
     feh # Lightweight image viewer and wallpaper setter
-    dosbox-staging # DOS emulator for legacy software
     libmpg123 # MP3 decoding library
     pipes # Fun terminal pipe animations
     cbonsai # Bonsai tree generator for the terminal
@@ -118,7 +136,6 @@ let
 
   # 2.13: System Monitoring & Information Tools
   pkgs2_13 = with pkgs; [
-    crosspipe # Graphical audio routing tool
     upscayl # AI-powered image upscaling tool
     btop # Resource monitor for system metrics
     lm_sensors # Hardware monitoring tool
@@ -147,7 +164,6 @@ let
 
   # 2.16: Communication Tools
   pkgs2_16 = with pkgs; [
-    vesktop # Communication application (verify details online)
   ];
 
   # 2.17: Text Processing & Document Conversion
@@ -199,11 +215,6 @@ let
     gdu # Disk usage analyzer
   ];
 
-  # 2.24: Wine for Windows Applications
-  pkgs2_24 = with pkgs; [
-    wineWow64Packages.waylandFull # Wine package optimized for Wayland
-  ];
-
   # 2.25: Screenshots & Wallpaper Management
   pkgs2_25 = with pkgs; [
     hyprshot # Screenshot utility for Hyprland
@@ -221,21 +232,6 @@ let
     brightnessctl # Command-line brightness controller
   ];
 
-  # 2.27: Gaming Tools & Enhancements
-  pkgs2_27 = with pkgs; [
-    radeontop # Monitor Radeon GPU usage in real time
-    gamescope # Compositor for game streaming and recording
-    prismlauncher # Game launcher for Linux
-    mangohud # On-screen display for monitoring game performance
-    heroic # Alternative game launcher (for Epic Games, etc.)
-    protonup-qt # GUI tool to update Proton versions
-    protontricks # Utility for managing Proton tweaks
-    gwe
-    retroarch-full
-    lsfg-vk
-    lsfg-vk-ui
-  ];
-
   # 2.28: Xorg Specific Tools
   pkgs2_28 = with pkgs; [
     xdotool # Automate X window interactions
@@ -243,7 +239,6 @@ let
     unixtools.xxd # Hex dump utility
     xwininfo # Display information about X windows
     yad # Yet Another Dialog for X (GUI dialogs)
-    steamtinkerlaunch # Tool to tweak Steam launch options
     steam-run # Run programs in FHS environment
   ];
 
@@ -294,10 +289,9 @@ in
     pkgs2_21 ++
     pkgs2_22 ++
     pkgs2_23 ++
-    pkgs2_24 ++
     pkgs2_25 ++
     pkgs2_26 ++
-    pkgs2_27 ++
     pkgs2_28 ++
-    stablepkgs; # Append any additional stable packages (e.g., kicad)
+    unstableGamingPkgs ++
+    unstableCompatibilityPkgs;
 }

--- a/packages/desktop.nix
+++ b/packages/desktop.nix
@@ -1,6 +1,11 @@
-{ pkgs, pkgs-stable, ... }:
+{ pkgs, pkgs-unstable, ... }:
 
 let
+  unstableGamingDesktopPkgs = with pkgs-unstable; [
+    alvr # VR
+    nvidia_oc
+  ];
+
   # 3.1: Digital Audio Workstations (DAWs)
   pkgs3_1 = with pkgs; [
     reaper # Main DAW application
@@ -21,17 +26,16 @@ let
 
   # 3.4: Bench & Overcklocking
   pkgs3_4 = with pkgs; [
-    nvidia_oc
     phoronix-test-suite
   ];
 
   # 3.5: Steam utilities
-  pkgs3_5 = with pkgs-stable; [
+  pkgs3_5 = with pkgs; [
     sgdboop # Steam artwork manager
-    alvr # VR
   ];
 
 in
 {
-  environment.systemPackages = pkgs3_1 ++ pkgs3_2 ++ pkgs3_3 ++ pkgs3_4 ++ pkgs3_5;
+  environment.systemPackages =
+    pkgs3_1 ++ pkgs3_2 ++ pkgs3_3 ++ pkgs3_4 ++ pkgs3_5 ++ unstableGamingDesktopPkgs;
 }

--- a/scripts/check-hyprland-rules.sh
+++ b/scripts/check-hyprland-rules.sh
@@ -6,18 +6,28 @@ cd "$repo_root"
 
 fail=0
 
-if rg -n "windowrulev2\\s*=" .; then
-  echo "ERROR: deprecated windowrulev2 syntax found. Use windowrule with match:* props." >&2
+if rg -n "windowrule\\s*=.*,\\s*match:" .; then
+  echo "ERROR: unsupported match:* matcher syntax found in windowrule. Use windowrulev2 with class:/title:/initialTitle: matchers." >&2
   fail=1
 fi
 
 if rg -n "windowrule\\s*=.*(class:|title:|initialTitle:|initialClass:)" .; then
-  echo "ERROR: legacy v2 matcher syntax found in windowrule. Use match:class/title/initial_title/initial_class." >&2
+  echo "ERROR: v2 matcher syntax found in windowrule. Use windowrulev2 for class:/title:/initialTitle:/initialClass: matchers." >&2
   fail=1
 fi
 
-if rg -n "windowrule\\s*=.*stayfocused" .; then
-  echo "ERROR: deprecated stayfocused rule found. Use stay_focused." >&2
+if rg -n "windowrulev2\\s*=.*stay_focused" .; then
+  echo "ERROR: unsupported stay_focused rule found. Use stayfocused for stable Hyprland windowrulev2 syntax." >&2
+  fail=1
+fi
+
+if rg -n "layerrule\\s*\\{" --glob "*.conf" .; then
+  echo "ERROR: unsupported layerrule block syntax found. Use 'layerrule = rule, namespace' syntax." >&2
+  fail=1
+fi
+
+if rg -n "match:namespace" --glob "*.conf" .; then
+  echo "ERROR: unsupported match:namespace syntax found. Use layerrule namespace regex as the second field." >&2
   fail=1
 fi
 


### PR DESCRIPTION
## Objective

This PR aligns the NixOS configuration with a clearer channel policy: `nixpkgs` is now the default stable channel, while `nixpkgs-unstable` is kept only for explicit exceptions, mainly gaming, compatibility, or packages missing from stable.

It also updates the documentation to reflect this new organization and makes the documentation workflow reproducible through `mkdocs.nix`.

## Main changes

### Flake / Nix channels

- Switch `nixpkgs` to `nixos-25.11` as the main stable channel.
- Remove the redundant `nixpkgs-stable` input.
- Keep `nixpkgs-unstable` for explicit package exceptions.
- Align `home-manager` and `stylix` with their `release-25.11` branches.
- Pass `pkgs-unstable` to both `desktop` and `laptop` through `specialArgs`.
- Pass `pkgs-unstable` to Home Manager modules through `home-manager.extraSpecialArgs`.

### Packages

- Replace the previous `pkgs-stable` / `stablepkgs` logic.
- Use `pkgs` as the default package source.
- Group packages coming from `pkgs-unstable` into explicit lists:
  - `unstableGamingPkgs`
  - `unstableCompatibilityPkgs`
  - `unstableGamingDesktopPkgs`
- Move selected gaming and compatibility packages to `pkgs-unstable`.
- Update `home-laptop.nix` to use `pkgs-unstable.moonlight-qt`.

### Home Manager / Neovim

- Update the Neovim Home Manager configuration:
  - replace `initLua` with `extraLuaConfig`.

### Hyprland

- Migrate Hyprland rules to the `windowrulev2` syntax.
- Replace the block-based `layerrule` syntax with the inline syntax.
- Update `check-hyprland-rules.sh` to validate the expected stable Hyprland rule syntax.

### Documentation

- Add a `mkdocs.nix` shell to run and build the documentation reproducibly.
- Update documentation commands:
  - `nix-shell mkdocs.nix --run "mkdocs serve"`
  - `nix-shell mkdocs.nix --run "mkdocs build"`
- Update both French and English documentation for:
  - flake inputs,
  - branch policy,
  - adding a new host,
  - package groups,
  - flake update workflow,
  - the convention around using `pkgs` by default and `pkgs-unstable` only for explicit exceptions.

## Validation

To validate:

```sh
nix flake show
nix flake check --no-build
sudo nixos-rebuild dry-activate --flake .#desktop
sudo nixos-rebuild dry-activate --flake .#laptop
./scripts/check-hyprland-rules.sh
nix-shell mkdocs.nix --run "mkdocs build"